### PR TITLE
[FEAT] 밴드 스크랩/취향/키워드 설정 및 검색 성능 최적화

### DIFF
--- a/src/main/java/ceos/diggindie/common/exception/ExceptionAdvice.java
+++ b/src/main/java/ceos/diggindie/common/exception/ExceptionAdvice.java
@@ -2,6 +2,7 @@ package ceos.diggindie.common.exception;
 
 import ceos.diggindie.common.response.ApiResponse;
 import ceos.diggindie.common.status.ErrorStatus;
+import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.convert.ConversionFailedException;
@@ -20,8 +21,8 @@ public class ExceptionAdvice {
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ApiResponse<Void>> handleConstraintViolation(ConstraintViolationException e) {
         String errorMessage = e.getConstraintViolations().stream()
-                .map(violation -> violation.getMessage())
                 .findFirst()
+                .map(ConstraintViolation::getMessage)
                 .orElse("입력값이 올바르지 않습니다.");
 
         log.warn("ConstraintViolationException: {}", errorMessage);

--- a/src/main/java/ceos/diggindie/common/response/ApiResponse.java
+++ b/src/main/java/ceos/diggindie/common/response/ApiResponse.java
@@ -61,7 +61,6 @@ public class ApiResponse<T> {
     }
 
     // 성공 - 페이지네이션 포함
-// 성공 - 페이지네이션 포함
     public static <T> ResponseEntity<ApiResponse<java.util.List<T>>> onSuccess(SuccessStatus status, Page<T> page) {
         PageInfo pageInfo = new PageInfo(
                 page.getNumber(),

--- a/src/main/java/ceos/diggindie/domain/band/controller/BandController.java
+++ b/src/main/java/ceos/diggindie/domain/band/controller/BandController.java
@@ -1,10 +1,24 @@
 package ceos.diggindie.domain.band.controller;
 
+import ceos.diggindie.common.config.security.CustomUserDetails;
+import ceos.diggindie.common.exception.GeneralException;
+import ceos.diggindie.common.response.ApiResponse;
+import ceos.diggindie.common.status.SuccessStatus;
+import ceos.diggindie.domain.band.dto.BandListResponse;
+import ceos.diggindie.domain.band.dto.BandScrapRequest;
+import ceos.diggindie.domain.band.dto.BandScrapResponse;
 import ceos.diggindie.domain.band.service.BandService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,4 +40,38 @@ public class BandController {
         bandService.processArtists();
     }
 
+    /* 밴드 검색, 밴드 취향 설정 (GET, POST) */
+
+    @GetMapping("/artists/lists")
+    public ResponseEntity<ApiResponse<List<BandListResponse>>> getBandList(
+            @RequestParam(required = false, defaultValue = "") String query,
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @RequestParam(required = false, defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<BandListResponse> bands = bandService.getBandList(query, pageable);
+
+        return ApiResponse.onSuccess(SuccessStatus._OK, bands);
+    }
+
+    @PostMapping("/artists/preferences")
+    public ResponseEntity<ApiResponse<Void>> saveBandPreferences(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody BandScrapRequest request
+    ) {
+        if (userDetails == null) throw GeneralException.loginRequired();
+
+        bandService.saveBandPreferences(userDetails.getUserId(), request);
+        return ApiResponse.onSuccess(SuccessStatus._CREATED);
+    }
+
+    @GetMapping("/artists/preferences")
+    public ResponseEntity<ApiResponse<BandScrapResponse>> getBandPreferences(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) throw GeneralException.loginRequired();
+
+        BandScrapResponse response = bandService.getBandPreferences(userDetails.getUserId());
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
 }

--- a/src/main/java/ceos/diggindie/domain/band/controller/BandController.java
+++ b/src/main/java/ceos/diggindie/domain/band/controller/BandController.java
@@ -1,22 +1,15 @@
 package ceos.diggindie.domain.band.controller;
 
-import ceos.diggindie.common.config.security.CustomUserDetails;
-import ceos.diggindie.common.exception.GeneralException;
 import ceos.diggindie.common.response.ApiResponse;
-import ceos.diggindie.common.response.PageInfo;
 import ceos.diggindie.common.status.SuccessStatus;
 import ceos.diggindie.domain.band.dto.BandListResponse;
-import ceos.diggindie.domain.band.dto.BandScrapRequest;
-import ceos.diggindie.domain.band.dto.BandScrapResponse;
 import ceos.diggindie.domain.band.service.BandService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -41,7 +34,7 @@ public class BandController {
         bandService.processArtists();
     }
 
-    /* 밴드 검색, 밴드 취향 설정 (GET, POST) */
+    /* 밴드 검색 */
 
     @GetMapping("/artists/lists")
     public ResponseEntity<ApiResponse<List<BandListResponse>>> getBandList(
@@ -53,48 +46,5 @@ public class BandController {
         Page<BandListResponse> bands = bandService.getBandList(query, pageable);
 
         return ApiResponse.onSuccess(SuccessStatus._OK, bands);
-    }
-
-    @PostMapping("/artists/preferences")
-    public ResponseEntity<ApiResponse<Void>> saveBandScraps(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Valid @RequestBody BandScrapRequest request
-    ) {
-        bandService.saveBandScraps(userDetails.getUserId(), request);
-        return ApiResponse.onSuccess(SuccessStatus._CREATED);
-    }
-
-    @GetMapping("/artists/preferences")
-    public ResponseEntity<ApiResponse<BandScrapResponse.BandScrapPageResponse>> getBandScraps(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size
-    ) {
-        if (userDetails == null) throw GeneralException.loginRequired();
-
-        Pageable pageable = PageRequest.of(page, size);
-
-        Page<BandScrapResponse.BandScrapInfoDTO> scrapPage =
-                bandService.getBandScraps(userDetails.getUserId(), pageable);
-
-        BandScrapResponse.BandScrapPageResponse payload =
-                BandScrapResponse.BandScrapPageResponse.builder()
-                        .scraps(scrapPage.getContent())
-                        .build();
-
-        return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
-                .body(ApiResponse.<BandScrapResponse.BandScrapPageResponse>builder()
-                        .statusCode(SuccessStatus._OK.getHttpStatus().value())
-                        .isSuccess(true)
-                        .message("스크랩 목록 조회 성공")
-                        .pageInfo(new PageInfo(
-                                scrapPage.getNumber(),
-                                scrapPage.getSize(),
-                                scrapPage.hasNext(),
-                                scrapPage.getTotalElements(),
-                                scrapPage.getTotalPages()
-                        ))
-                        .payload(payload)
-                        .build());
     }
 }

--- a/src/main/java/ceos/diggindie/domain/band/controller/BandController.java
+++ b/src/main/java/ceos/diggindie/domain/band/controller/BandController.java
@@ -36,7 +36,7 @@ public class BandController {
 
     /* 밴드 검색 */
 
-    @GetMapping("/artists/lists")
+    @GetMapping("/artists")
     public ResponseEntity<ApiResponse<List<BandListResponse>>> getBandList(
             @RequestParam(required = false, defaultValue = "") String query,
             @RequestParam(required = false, defaultValue = "0") int page,

--- a/src/main/java/ceos/diggindie/domain/band/controller/BandScrapController.java
+++ b/src/main/java/ceos/diggindie/domain/band/controller/BandScrapController.java
@@ -23,7 +23,7 @@ public class BandScrapController {
 
     private final BandScrapService bandScrapService;
 
-    @PostMapping("/artists/scraps")
+    @PostMapping("/my/artists")
     public ResponseEntity<ApiResponse<Void>> saveBandScraps(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody BandScrapRequest request
@@ -34,7 +34,7 @@ public class BandScrapController {
         return ApiResponse.onSuccess(SuccessStatus._CREATED);
     }
 
-    @GetMapping("/artists/scraps")
+    @GetMapping("/my/artists")
     public ResponseEntity<ApiResponse<BandScrapResponse.BandScrapPageResponse>> getBandScraps(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/ceos/diggindie/domain/band/controller/BandScrapController.java
+++ b/src/main/java/ceos/diggindie/domain/band/controller/BandScrapController.java
@@ -1,0 +1,70 @@
+package ceos.diggindie.domain.band.controller;
+
+import ceos.diggindie.common.config.security.CustomUserDetails;
+import ceos.diggindie.common.exception.GeneralException;
+import ceos.diggindie.common.response.ApiResponse;
+import ceos.diggindie.common.response.PageInfo;
+import ceos.diggindie.common.status.SuccessStatus;
+import ceos.diggindie.domain.band.dto.BandScrapRequest;
+import ceos.diggindie.domain.band.dto.BandScrapResponse;
+import ceos.diggindie.domain.band.service.BandScrapService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class BandScrapController {
+
+    private final BandScrapService bandScrapService;
+
+    @PostMapping("/artists/scraps")
+    public ResponseEntity<ApiResponse<Void>> saveBandScraps(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody BandScrapRequest request
+    ) {
+        if (userDetails == null) throw GeneralException.loginRequired();
+
+        bandScrapService.saveBandScraps(userDetails.getUserId(), request);
+        return ApiResponse.onSuccess(SuccessStatus._CREATED);
+    }
+
+    @GetMapping("/artists/scraps")
+    public ResponseEntity<ApiResponse<BandScrapResponse.BandScrapPageResponse>> getBandScraps(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        if (userDetails == null) throw GeneralException.loginRequired();
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        Page<BandScrapResponse.BandScrapInfoDTO> scrapPage =
+                bandScrapService.getBandScraps(userDetails.getUserId(), pageable);
+
+        BandScrapResponse.BandScrapPageResponse payload =
+                BandScrapResponse.BandScrapPageResponse.builder()
+                        .scraps(scrapPage.getContent())
+                        .build();
+
+        return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
+                .body(ApiResponse.<BandScrapResponse.BandScrapPageResponse>builder()
+                        .statusCode(SuccessStatus._OK.getHttpStatus().value())
+                        .isSuccess(true)
+                        .message("스크랩 목록 조회 성공")
+                        .pageInfo(new PageInfo(
+                                scrapPage.getNumber(),
+                                scrapPage.getSize(),
+                                scrapPage.hasNext(),
+                                scrapPage.getTotalElements(),
+                                scrapPage.getTotalPages()
+                        ))
+                        .payload(payload)
+                        .build());
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/band/dto/BandListResponse.java
+++ b/src/main/java/ceos/diggindie/domain/band/dto/BandListResponse.java
@@ -1,0 +1,18 @@
+package ceos.diggindie.domain.band.dto;
+
+import lombok.Builder;
+
+@Builder
+public record BandListResponse(
+        Long bandId,
+        String imageUrl,
+        String bandName
+) {
+    public static BandListResponse from(ceos.diggindie.domain.band.entity.Band band) {
+        return BandListResponse.builder()
+                .bandId(band.getId())
+                .imageUrl(band.getMainImage())
+                .bandName(band.getBandName())
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/band/dto/BandScrapRequest.java
+++ b/src/main/java/ceos/diggindie/domain/band/dto/BandScrapRequest.java
@@ -1,0 +1,10 @@
+package ceos.diggindie.domain.band.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record BandScrapRequest(
+        @NotNull(message = "밴드 ID 리스트는 필수입니다.")
+        List<Long> bandIds
+) {}

--- a/src/main/java/ceos/diggindie/domain/band/dto/BandScrapResponse.java
+++ b/src/main/java/ceos/diggindie/domain/band/dto/BandScrapResponse.java
@@ -1,16 +1,25 @@
 package ceos.diggindie.domain.band.dto;
 
 import lombok.Builder;
+import lombok.Getter;
 
 import java.util.List;
 
-@Builder
-public record BandScrapResponse(
-        List<BandListResponse> bands
-) {
-    public static BandScrapResponse of(List<BandListResponse> bands) {
-        return BandScrapResponse.builder()
-                .bands(bands)
-                .build();
+public class BandScrapResponse {
+
+    @Getter
+    @Builder
+    public static class BandScrapPageResponse {
+        private List<BandScrapInfoDTO> scraps;
+    }
+
+    @Getter
+    @Builder
+    public static class BandScrapInfoDTO {
+        private Long bandId;
+        private String bandName;
+        private List<String> keywords;
+        private String bandImage;
+        private String mainMusic;
     }
 }

--- a/src/main/java/ceos/diggindie/domain/band/dto/BandScrapResponse.java
+++ b/src/main/java/ceos/diggindie/domain/band/dto/BandScrapResponse.java
@@ -1,25 +1,18 @@
 package ceos.diggindie.domain.band.dto;
 
-import lombok.Builder;
-import lombok.Getter;
-
 import java.util.List;
 
 public class BandScrapResponse {
 
-    @Getter
-    @Builder
-    public static class BandScrapPageResponse {
-        private List<BandScrapInfoDTO> scraps;
-    }
+    public record BandScrapPageResponse(
+            List<BandScrapInfoDTO> scraps
+    ) {}
 
-    @Getter
-    @Builder
-    public static class BandScrapInfoDTO {
-        private Long bandId;
-        private String bandName;
-        private List<String> keywords;
-        private String bandImage;
-        private String mainMusic;
-    }
+    public record BandScrapInfoDTO(
+            Long bandId,
+            String bandName,
+            List<String> keywords,
+            String bandImage,
+            String mainMusic
+    ) {}
 }

--- a/src/main/java/ceos/diggindie/domain/band/dto/BandScrapResponse.java
+++ b/src/main/java/ceos/diggindie/domain/band/dto/BandScrapResponse.java
@@ -1,0 +1,16 @@
+package ceos.diggindie.domain.band.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record BandScrapResponse(
+        List<BandListResponse> bands
+) {
+    public static BandScrapResponse of(List<BandListResponse> bands) {
+        return BandScrapResponse.builder()
+                .bands(bands)
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/band/entity/Band.java
+++ b/src/main/java/ceos/diggindie/domain/band/entity/Band.java
@@ -60,8 +60,8 @@ public class Band extends BaseEntity {
     @OneToMany(mappedBy = "band")
     private List<BandRecommend> artistRecommends = new ArrayList<>();
 
-    @OneToMany(mappedBy = "band")
-    private List<BandScrap> artistScraps = new ArrayList<>();
+    @OneToMany(mappedBy = "band", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<BandScrap> bandScraps = new ArrayList<>();
 
     @Builder
     public Band(

--- a/src/main/java/ceos/diggindie/domain/band/entity/BandScrap.java
+++ b/src/main/java/ceos/diggindie/domain/band/entity/BandScrap.java
@@ -19,24 +19,15 @@ public class BandScrap extends BaseEntity {
     @Column(name = "band_scrap_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    private Long memberId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "band_id", nullable = false)
     private Band band;
 
     @Builder
-    public BandScrap(Member member, Band band) {
-        this.member = member;
+    public BandScrap(Long memberId, Band band) {
+        this.memberId = memberId;
         this.band = band;
-    }
-
-    public static BandScrap of(Member member, Band band) {
-        return BandScrap.builder()
-                .member(member)
-                .band(band)
-                .build();
     }
 }

--- a/src/main/java/ceos/diggindie/domain/band/entity/BandScrap.java
+++ b/src/main/java/ceos/diggindie/domain/band/entity/BandScrap.java
@@ -4,6 +4,7 @@ import ceos.diggindie.common.entity.BaseEntity;
 import ceos.diggindie.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,4 +27,16 @@ public class BandScrap extends BaseEntity {
     @JoinColumn(name = "band_id", nullable = false)
     private Band band;
 
+    @Builder
+    public BandScrap(Member member, Band band) {
+        this.member = member;
+        this.band = band;
+    }
+
+    public static BandScrap of(Member member, Band band) {
+        return BandScrap.builder()
+                .member(member)
+                .band(band)
+                .build();
+    }
 }

--- a/src/main/java/ceos/diggindie/domain/band/repository/BandRepository.java
+++ b/src/main/java/ceos/diggindie/domain/band/repository/BandRepository.java
@@ -1,10 +1,21 @@
 package ceos.diggindie.domain.band.repository;
 
 import ceos.diggindie.domain.band.entity.Band;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface BandRepository extends JpaRepository<Band, Long> {
     Optional<Band> findByBandName(String bandName);
+
+    @Query("SELECT DISTINCT b FROM Band b " +
+            "LEFT JOIN b.bandKeywords bk " +
+            "LEFT JOIN bk.keyword k " +
+            "WHERE :query IS NULL OR :query = '' OR " +
+            "b.bandName LIKE %:query% OR k.keyword LIKE %:query%")
+    Page<Band> searchBands(@Param("query") String query, Pageable pageable);
 }

--- a/src/main/java/ceos/diggindie/domain/band/repository/BandRepository.java
+++ b/src/main/java/ceos/diggindie/domain/band/repository/BandRepository.java
@@ -12,10 +12,17 @@ import java.util.Optional;
 public interface BandRepository extends JpaRepository<Band, Long> {
     Optional<Band> findByBandName(String bandName);
 
-    @Query("SELECT DISTINCT b FROM Band b " +
-            "LEFT JOIN b.bandKeywords bk " +
-            "LEFT JOIN bk.keyword k " +
+    @Query(value = "SELECT DISTINCT b FROM Band b " +
+            "LEFT JOIN FETCH b.bandKeywords bk " +
+            "LEFT JOIN FETCH bk.keyword k " +
             "WHERE :query IS NULL OR :query = '' OR " +
-            "b.bandName LIKE %:query% OR k.keyword LIKE %:query%")
+            "b.bandName ILIKE %:query% OR " + // ILIKE + GIN
+            "k.keyword ILIKE %:query%",
+            countQuery = "SELECT count(DISTINCT b) FROM Band b " +
+                    "LEFT JOIN b.bandKeywords bk " +
+                    "LEFT JOIN bk.keyword k " +
+                    "WHERE :query IS NULL OR :query = '' OR " +
+                    "b.bandName ILIKE %:query% OR " +
+                    "k.keyword ILIKE %:query%")
     Page<Band> searchBands(@Param("query") String query, Pageable pageable);
 }

--- a/src/main/java/ceos/diggindie/domain/band/repository/BandScrapRepository.java
+++ b/src/main/java/ceos/diggindie/domain/band/repository/BandScrapRepository.java
@@ -1,0 +1,18 @@
+package ceos.diggindie.domain.band.repository;
+
+import ceos.diggindie.domain.band.entity.BandScrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface BandScrapRepository extends JpaRepository<BandScrap, Long> {
+
+    @Modifying
+    @Query("DELETE FROM BandScrap bs WHERE bs.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
+
+    List<BandScrap> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/ceos/diggindie/domain/band/repository/BandScrapRepository.java
+++ b/src/main/java/ceos/diggindie/domain/band/repository/BandScrapRepository.java
@@ -4,7 +4,6 @@ import ceos.diggindie.domain.band.entity.BandScrap;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,15 +11,17 @@ import java.util.List;
 
 public interface BandScrapRepository extends JpaRepository<BandScrap, Long> {
 
-    @Modifying
-    @Query("DELETE FROM BandScrap bs WHERE bs.member.id = :memberId")
-    void deleteAllByMemberId(@Param("memberId") Long memberId);
+    void deleteAllByMemberId(Long memberId);
 
     @Query(value = "SELECT bs FROM BandScrap bs " +
             "JOIN FETCH bs.band b " +
             "LEFT JOIN FETCH b.bandKeywords bk " +
             "LEFT JOIN FETCH bk.keyword " +
-            "WHERE bs.member.id = :memberId",
-            countQuery = "SELECT count(bs) FROM BandScrap bs WHERE bs.member.id = :memberId")
+            "WHERE bs.memberId = :memberId",
+            countQuery = "SELECT count(bs) FROM BandScrap bs WHERE bs.memberId = :memberId")
     Page<BandScrap> findAllByMemberIdWithKeywords(@Param("memberId") Long memberId, Pageable pageable);
+
+    List<BandScrap> findAllByMemberId(Long memberId);
+
+    void deleteByMemberIdAndBandId(Long memberId, Long bandId);
 }

--- a/src/main/java/ceos/diggindie/domain/band/repository/BandScrapRepository.java
+++ b/src/main/java/ceos/diggindie/domain/band/repository/BandScrapRepository.java
@@ -1,6 +1,8 @@
 package ceos.diggindie.domain.band.repository;
 
 import ceos.diggindie.domain.band.entity.BandScrap;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -14,5 +16,11 @@ public interface BandScrapRepository extends JpaRepository<BandScrap, Long> {
     @Query("DELETE FROM BandScrap bs WHERE bs.member.id = :memberId")
     void deleteAllByMemberId(@Param("memberId") Long memberId);
 
-    List<BandScrap> findAllByMemberId(Long memberId);
+    @Query(value = "SELECT bs FROM BandScrap bs " +
+            "JOIN FETCH bs.band b " +
+            "LEFT JOIN FETCH b.bandKeywords bk " +
+            "LEFT JOIN FETCH bk.keyword " +
+            "WHERE bs.member.id = :memberId",
+            countQuery = "SELECT count(bs) FROM BandScrap bs WHERE bs.member.id = :memberId")
+    Page<BandScrap> findAllByMemberIdWithKeywords(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/src/main/java/ceos/diggindie/domain/band/service/BandScrapService.java
+++ b/src/main/java/ceos/diggindie/domain/band/service/BandScrapService.java
@@ -1,0 +1,65 @@
+package ceos.diggindie.domain.band.service;
+
+import ceos.diggindie.common.exception.GeneralException;
+import ceos.diggindie.domain.band.dto.BandScrapRequest;
+import ceos.diggindie.domain.band.dto.BandScrapResponse;
+import ceos.diggindie.domain.band.entity.Band;
+import ceos.diggindie.domain.band.entity.BandScrap;
+import ceos.diggindie.domain.band.repository.BandRepository;
+import ceos.diggindie.domain.band.repository.BandScrapRepository;
+import ceos.diggindie.domain.member.entity.Member;
+import ceos.diggindie.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BandScrapService {
+
+    private final BandScrapRepository bandScrapRepository;
+    private final MemberRepository memberRepository;
+    private final BandRepository bandRepository;
+
+    @Transactional
+    public void saveBandScraps(Long userId, BandScrapRequest request) {
+        bandScrapRepository.deleteAllByMemberId(userId);
+
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> GeneralException.notFound("사용자를 찾을 수 없습니다."));
+
+        List<Band> bands = bandRepository.findAllById(request.bandIds());
+
+        List<BandScrap> scraps = bands.stream()
+                .map(band -> BandScrap.of(member, band))
+                .toList();
+
+        bandScrapRepository.saveAll(scraps);
+    }
+
+    public Page<BandScrapResponse.BandScrapInfoDTO> getBandScraps(Long userId, Pageable pageable) {
+        Page<BandScrap> scrapPage = bandScrapRepository.findAllByMemberIdWithKeywords(userId, pageable);
+
+        return scrapPage.map(scrap -> {
+            Band band = scrap.getBand();
+
+            List<String> keywords = band.getBandKeywords().stream()
+                    .map(bk -> bk.getKeyword().getKeyword())
+                    .collect(Collectors.toList());
+
+            return BandScrapResponse.BandScrapInfoDTO.builder()
+                    .bandId(band.getId())
+                    .bandName(band.getBandName())
+                    .keywords(keywords)
+                    .bandImage(band.getMainImage())
+                    .mainMusic(band.getMainMusic())
+                    .build();
+        });
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/band/service/BandScrapService.java
+++ b/src/main/java/ceos/diggindie/domain/band/service/BandScrapService.java
@@ -35,6 +35,7 @@ public class BandScrapService {
                 .orElseThrow(() -> GeneralException.notFound("사용자를 찾을 수 없습니다."));
 
         List<Band> bands = bandRepository.findAllById(request.bandIds());
+        // 위 부분에서 요청 밴드 중 일부가 없어도 예외 발생 안하도록 하는게 맞는지 수정 필요
 
         List<BandScrap> scraps = bands.stream()
                 .map(band -> BandScrap.of(member, band))

--- a/src/main/java/ceos/diggindie/domain/concert/controller/ConcertController.java
+++ b/src/main/java/ceos/diggindie/domain/concert/controller/ConcertController.java
@@ -1,0 +1,34 @@
+package ceos.diggindie.domain.concert.controller;
+
+import ceos.diggindie.common.config.security.CustomUserDetails;
+import ceos.diggindie.common.exception.GeneralException;
+import ceos.diggindie.common.response.ApiResponse;
+import ceos.diggindie.common.status.SuccessStatus;
+import ceos.diggindie.domain.concert.dto.ConcertScrapResponse;
+import ceos.diggindie.domain.concert.service.ConcertScrapService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ConcertController {
+
+    private final ConcertScrapService concertScrapService;
+
+    @GetMapping("/my/concerts")
+    public ResponseEntity<ApiResponse<ConcertScrapResponse.ConcertScrapListDTO>> getMyScrappedConcerts(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        if (customUserDetails == null) {
+            throw GeneralException.loginRequired();
+        }
+
+        ConcertScrapResponse.ConcertScrapListDTO response =
+                concertScrapService.getMyScrappedConcerts(customUserDetails.getUserId());
+
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/concert/controller/ConcertController.java
+++ b/src/main/java/ceos/diggindie/domain/concert/controller/ConcertController.java
@@ -1,13 +1,13 @@
 package ceos.diggindie.domain.concert.controller;
 
 import ceos.diggindie.common.config.security.CustomUserDetails;
-import ceos.diggindie.common.exception.GeneralException;
 import ceos.diggindie.common.response.ApiResponse;
 import ceos.diggindie.common.status.SuccessStatus;
 import ceos.diggindie.domain.concert.dto.ConcertScrapResponse;
 import ceos.diggindie.domain.concert.service.ConcertScrapService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,13 +18,10 @@ public class ConcertController {
 
     private final ConcertScrapService concertScrapService;
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/my/concerts")
     public ResponseEntity<ApiResponse<ConcertScrapResponse.ConcertScrapListDTO>> getMyScrappedConcerts(
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-
-        if (customUserDetails == null) {
-            throw GeneralException.loginRequired();
-        }
 
         ConcertScrapResponse.ConcertScrapListDTO response =
                 concertScrapService.getMyScrappedConcerts(customUserDetails.getUserId());

--- a/src/main/java/ceos/diggindie/domain/concert/dto/ConcertScrapResponse.java
+++ b/src/main/java/ceos/diggindie/domain/concert/dto/ConcertScrapResponse.java
@@ -1,0 +1,26 @@
+package ceos.diggindie.domain.concert.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+public class ConcertScrapResponse {
+
+    @Getter
+    @Builder
+    public static class ConcertScrapListDTO {
+        private List<ConcertScrapInfoDTO> concerts;
+    }
+
+    @Getter
+    @Builder
+    public static class ConcertScrapInfoDTO {
+        private Long concertId;
+        private String concertName;
+        private String duration;
+        private String dDay;
+        private String imageUrl;
+        private boolean isFinished;
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/concert/repository/ConcertScrapRepository.java
+++ b/src/main/java/ceos/diggindie/domain/concert/repository/ConcertScrapRepository.java
@@ -1,0 +1,30 @@
+package ceos.diggindie.domain.concert.repository;
+
+import ceos.diggindie.domain.concert.entity.ConcertScrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ConcertScrapRepository extends JpaRepository<ConcertScrap, Long> {
+
+    /**
+     * 특정 멤버의 스크랩 목록을 조회합니다.
+     * fetch join을 사용하여 연관된 Concert 엔티티를 한 번에 가져옵니다. (N+1 방지)
+     */
+    @Query("SELECT cs FROM ConcertScrap cs " +
+            "JOIN FETCH cs.concert " +
+            "WHERE cs.member.id = :memberId")
+    List<ConcertScrap> findAllByMemberIdWithConcert(@Param("memberId") Long memberId);
+
+    /**
+     * 특정 멤버가 특정 공연을 이미 스크랩했는지 확인 (중복 체크용 - 필요시 사용)
+     */
+    boolean existsByMemberIdAndConcertId(Long memberId, Long concertId);
+
+    /**
+     * 스크랩 취소 시 사용 (삭제)
+     */
+    void deleteByMemberIdAndConcertId(Long memberId, Long concertId);
+}

--- a/src/main/java/ceos/diggindie/domain/concert/service/ConcertScrapService.java
+++ b/src/main/java/ceos/diggindie/domain/concert/service/ConcertScrapService.java
@@ -4,7 +4,6 @@ import ceos.diggindie.domain.concert.dto.ConcertScrapResponse;
 import ceos.diggindie.domain.concert.entity.Concert;
 import ceos.diggindie.domain.concert.entity.ConcertScrap;
 import ceos.diggindie.domain.concert.repository.ConcertScrapRepository;
-import ceos.diggindie.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,15 +59,21 @@ public class ConcertScrapService {
         }
     }
 
-    private String formatDuration(LocalDate start, LocalDate end) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.d");
+    private static final DateTimeFormatter FULL_FORMAT = DateTimeFormatter.ofPattern("yyyy.MM.d");
+    private static final DateTimeFormatter MONTH_DAY_FORMAT = DateTimeFormatter.ofPattern("MM.d");
 
+    private String formatDuration(LocalDate start, LocalDate end) {
+        // 연도와 월이 같은 경우: "2025.12.1 ~ 3"
         if (start.getYear() == end.getYear() && start.getMonth() == end.getMonth()) {
-            return start.format(formatter) + " ~ " + end.getDayOfMonth();
+            return start.format(FULL_FORMAT) + " ~ " + end.getDayOfMonth();
         }
+
+        // 연도만 같은 경우: "2025.12.1 ~ 01.05"
         if (start.getYear() == end.getYear()) {
-            return start.format(formatter) + " ~ " + end.format(DateTimeFormatter.ofPattern("MM.d"));
+            return start.format(FULL_FORMAT) + " ~ " + end.format(MONTH_DAY_FORMAT);
         }
-        return start.format(formatter) + " ~ " + end.format(formatter);
+
+        // 연도가 다른 경우: "2025.12.31 ~ 2026.01.01"
+        return start.format(FULL_FORMAT) + " ~ " + end.format(FULL_FORMAT);
     }
 }

--- a/src/main/java/ceos/diggindie/domain/concert/service/ConcertScrapService.java
+++ b/src/main/java/ceos/diggindie/domain/concert/service/ConcertScrapService.java
@@ -36,7 +36,7 @@ public class ConcertScrapService {
                             .concertId(concert.getId())
                             .concertName(concert.getTitle())
                             .duration(formatDuration(startDate, endDate))
-                            .dDay(calculateDDay(startDate))
+                            .dDay(calculateDDay(startDate, endDate))
                             .imageUrl(concert.getMainImg())
                             .isFinished(concert.getEndDate() != null && concert.getEndDate().isBefore(LocalDateTime.now()))
                             .build();
@@ -48,10 +48,16 @@ public class ConcertScrapService {
                 .build();
     }
 
-    private String calculateDDay(LocalDate startDate) {
-        long days = ChronoUnit.DAYS.between(LocalDate.now(), startDate);
-        if (days == 0) return "D-Day";
-        return days > 0 ? "D-" + days : "D+" + Math.abs(days);
+    private String calculateDDay(LocalDate startDate, LocalDate endDate) {
+        LocalDate now = LocalDate.now();
+        if (now.isBefore(startDate)) {
+            long days = ChronoUnit.DAYS.between(now, startDate);
+            return days == 0 ? "D-Day" : "D-" + days;
+        } else if (now.isAfter(endDate)) {
+            return "종료";
+        } else {
+            return "진행 중";
+        }
     }
 
     private String formatDuration(LocalDate start, LocalDate end) {

--- a/src/main/java/ceos/diggindie/domain/concert/service/ConcertScrapService.java
+++ b/src/main/java/ceos/diggindie/domain/concert/service/ConcertScrapService.java
@@ -1,0 +1,68 @@
+package ceos.diggindie.domain.concert.service;
+
+import ceos.diggindie.domain.concert.dto.ConcertScrapResponse;
+import ceos.diggindie.domain.concert.entity.Concert;
+import ceos.diggindie.domain.concert.entity.ConcertScrap;
+import ceos.diggindie.domain.concert.repository.ConcertScrapRepository;
+import ceos.diggindie.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ConcertScrapService {
+
+    private final ConcertScrapRepository concertScrapRepository;
+
+    public ConcertScrapResponse.ConcertScrapListDTO getMyScrappedConcerts(Long userId) {
+        List<ConcertScrap> scraps = concertScrapRepository.findAllByMemberIdWithConcert(userId);
+
+        List<ConcertScrapResponse.ConcertScrapInfoDTO> concertInfos = scraps.stream()
+                .map(scrap -> {
+                    Concert concert = scrap.getConcert();
+                    LocalDate startDate = concert.getStartDate().toLocalDate();
+                    LocalDate endDate = (concert.getEndDate() != null) ? concert.getEndDate().toLocalDate() : startDate;
+
+                    return ConcertScrapResponse.ConcertScrapInfoDTO.builder()
+                            .concertId(concert.getId())
+                            .concertName(concert.getTitle())
+                            .duration(formatDuration(startDate, endDate))
+                            .dDay(calculateDDay(startDate))
+                            .imageUrl(concert.getMainImg())
+                            .isFinished(concert.getEndDate() != null && concert.getEndDate().isBefore(LocalDateTime.now()))
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return ConcertScrapResponse.ConcertScrapListDTO.builder()
+                .concerts(concertInfos)
+                .build();
+    }
+
+    private String calculateDDay(LocalDate startDate) {
+        long days = ChronoUnit.DAYS.between(LocalDate.now(), startDate);
+        if (days == 0) return "D-Day";
+        return days > 0 ? "D-" + days : "D+" + Math.abs(days);
+    }
+
+    private String formatDuration(LocalDate start, LocalDate end) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.d");
+
+        if (start.getYear() == end.getYear() && start.getMonth() == end.getMonth()) {
+            return start.format(formatter) + " ~ " + end.getDayOfMonth();
+        }
+        if (start.getYear() == end.getYear()) {
+            return start.format(formatter) + " ~ " + end.format(DateTimeFormatter.ofPattern("MM.d"));
+        }
+        return start.format(formatter) + " ~ " + end.format(formatter);
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/keyword/controller/KeywordController.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/controller/KeywordController.java
@@ -23,18 +23,26 @@ public class KeywordController {
 
     private final KeywordService keywordService;
 
+    @GetMapping("/keywords")
+    public ResponseEntity<ApiResponse<List<KeywordResponse>>> getAllKeywords() {
+        List<KeywordResponse> keywords = keywordService.getAllKeywords();
+        return ApiResponse.onSuccess(SuccessStatus._OK, keywords);
+    }
+
     @PostMapping("/my/keywords")
     public ResponseEntity<ApiResponse<Void>> saveKeywordPreferences(
             @AuthenticationPrincipal Member member,
             @Valid @RequestBody KeywordRequest request
     ) {
-        keywordService.saveKeywordPreferences(member, request);
+        keywordService.setMyKeywords(member, request);
         return ApiResponse.onSuccess(SuccessStatus._CREATED);
     }
 
     @GetMapping("/my/keywords")
-    public ResponseEntity<ApiResponse<List<KeywordResponse>>> getAllKeywords() {
-        List<KeywordResponse> keywords = keywordService.getAllKeywords();
+    public ResponseEntity<ApiResponse<List<KeywordResponse>>> getMyKeywords(
+            @AuthenticationPrincipal Member member
+    ) {
+        List<KeywordResponse> keywords = keywordService.getMyKeywords(member.getId());
         return ApiResponse.onSuccess(SuccessStatus._OK, keywords);
     }
 

--- a/src/main/java/ceos/diggindie/domain/keyword/controller/KeywordController.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/controller/KeywordController.java
@@ -1,11 +1,12 @@
 package ceos.diggindie.domain.keyword.controller;
 
+import ceos.diggindie.common.config.security.CustomUserDetails;
+import ceos.diggindie.common.exception.GeneralException;
 import ceos.diggindie.common.response.ApiResponse;
 import ceos.diggindie.common.status.SuccessStatus;
 import ceos.diggindie.domain.keyword.dto.KeywordRequest;
 import ceos.diggindie.domain.keyword.dto.KeywordResponse;
 import ceos.diggindie.domain.keyword.service.KeywordService;
-import ceos.diggindie.domain.member.entity.Member;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -31,18 +32,22 @@ public class KeywordController {
 
     @PostMapping("/my/keywords")
     public ResponseEntity<ApiResponse<Void>> saveKeywordPreferences(
-            @AuthenticationPrincipal Member member,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody KeywordRequest request
     ) {
-        keywordService.setMyKeywords(member, request);
+        if (userDetails == null) throw GeneralException.loginRequired();
+
+        keywordService.setMyKeywords(userDetails.getUserId(), request);
         return ApiResponse.onSuccess(SuccessStatus._CREATED);
     }
 
     @GetMapping("/my/keywords")
     public ResponseEntity<ApiResponse<List<KeywordResponse>>> getMyKeywords(
-            @AuthenticationPrincipal Member member
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        List<KeywordResponse> keywords = keywordService.getMyKeywords(member.getId());
+        if (userDetails == null) throw GeneralException.loginRequired();
+
+        List<KeywordResponse> keywords = keywordService.getMyKeywords(userDetails.getUserId());
         return ApiResponse.onSuccess(SuccessStatus._OK, keywords);
     }
 

--- a/src/main/java/ceos/diggindie/domain/keyword/controller/KeywordController.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/controller/KeywordController.java
@@ -1,0 +1,41 @@
+package ceos.diggindie.domain.keyword.controller;
+
+import ceos.diggindie.common.response.ApiResponse;
+import ceos.diggindie.common.status.SuccessStatus;
+import ceos.diggindie.domain.keyword.dto.KeywordRequest;
+import ceos.diggindie.domain.keyword.dto.KeywordResponse;
+import ceos.diggindie.domain.keyword.service.KeywordService;
+import ceos.diggindie.domain.member.entity.Member;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class KeywordController {
+
+    private final KeywordService keywordService;
+
+    @PostMapping("/my/keywords")
+    public ResponseEntity<ApiResponse<Void>> saveKeywordPreferences(
+            @AuthenticationPrincipal Member member,
+            @Valid @RequestBody KeywordRequest request
+    ) {
+        keywordService.saveKeywordPreferences(member, request);
+        return ApiResponse.onSuccess(SuccessStatus._CREATED);
+    }
+
+    @GetMapping("/my/keywords")
+    public ResponseEntity<ApiResponse<List<KeywordResponse>>> getAllKeywords() {
+        List<KeywordResponse> keywords = keywordService.getAllKeywords();
+        return ApiResponse.onSuccess(SuccessStatus._OK, keywords);
+    }
+
+}

--- a/src/main/java/ceos/diggindie/domain/keyword/dto/KeywordRequest.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/dto/KeywordRequest.java
@@ -1,0 +1,12 @@
+package ceos.diggindie.domain.keyword.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record KeywordRequest(
+        @NotNull(message = "키워드 ID 리스트는 필수입니다.")
+        @Size(min = 1, message = "최소 1개 이상의 키워드를 선택해야 합니다.")
+        List<Long> keywordIds
+) {}

--- a/src/main/java/ceos/diggindie/domain/keyword/dto/KeywordResponse.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/dto/KeywordResponse.java
@@ -1,0 +1,16 @@
+package ceos.diggindie.domain.keyword.dto;
+
+import lombok.Builder;
+
+@Builder
+public record KeywordResponse(
+        Long keywordId,
+        String keyword
+) {
+    public static KeywordResponse from(ceos.diggindie.domain.keyword.entity.Keyword keyword) {
+        return KeywordResponse.builder()
+                .keywordId(keyword.getId())
+                .keyword(keyword.getKeyword())
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/keyword/entity/MemberKeyword.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/entity/MemberKeyword.java
@@ -4,6 +4,7 @@ import ceos.diggindie.common.entity.BaseEntity;
 import ceos.diggindie.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,4 +26,17 @@ public class MemberKeyword extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "keyword_id", nullable = false)
     private Keyword keyword;
+
+    @Builder
+    public MemberKeyword(Member member, Keyword keyword) {
+        this.member = member;
+        this.keyword = keyword;
+    }
+
+    public static MemberKeyword of(Member member, Keyword keyword) {
+        return MemberKeyword.builder()
+                .member(member)
+                .keyword(keyword)
+                .build();
+    }
 }

--- a/src/main/java/ceos/diggindie/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/repository/KeywordRepository.java
@@ -1,0 +1,7 @@
+package ceos.diggindie.domain.keyword.repository;
+
+import ceos.diggindie.domain.keyword.entity.Keyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+}

--- a/src/main/java/ceos/diggindie/domain/keyword/repository/MemberKeywordRepository.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/repository/MemberKeywordRepository.java
@@ -3,9 +3,17 @@ package ceos.diggindie.domain.keyword.repository;
 import ceos.diggindie.domain.keyword.entity.MemberKeyword;
 import ceos.diggindie.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MemberKeywordRepository extends JpaRepository<MemberKeyword, Long> {
 
-    // 특정 회원의 모든 키워드 취향 삭제
     void deleteAllByMember(Member member);
+
+    @Query("SELECT mk FROM MemberKeyword mk " +
+            "JOIN FETCH mk.keyword " +
+            "WHERE mk.member.id = :memberId")
+    List<MemberKeyword> findAllByMemberIdWithKeyword(@Param("memberId") Long memberId);
 }

--- a/src/main/java/ceos/diggindie/domain/keyword/repository/MemberKeywordRepository.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/repository/MemberKeywordRepository.java
@@ -1,0 +1,11 @@
+package ceos.diggindie.domain.keyword.repository;
+
+import ceos.diggindie.domain.keyword.entity.MemberKeyword;
+import ceos.diggindie.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberKeywordRepository extends JpaRepository<MemberKeyword, Long> {
+
+    // 특정 회원의 모든 키워드 취향 삭제
+    void deleteAllByMember(Member member);
+}

--- a/src/main/java/ceos/diggindie/domain/keyword/service/KeywordService.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/service/KeywordService.java
@@ -9,6 +9,7 @@ import ceos.diggindie.domain.keyword.entity.MemberKeyword;
 import ceos.diggindie.domain.keyword.repository.KeywordRepository;
 import ceos.diggindie.domain.keyword.repository.MemberKeywordRepository;
 import ceos.diggindie.domain.member.entity.Member;
+import ceos.diggindie.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,7 @@ public class KeywordService {
 
     private final KeywordRepository keywordRepository;
     private final MemberKeywordRepository memberKeywordRepository;
+    private final MemberRepository memberRepository;
 
     public List<KeywordResponse> getAllKeywords() {
         return keywordRepository.findAll().stream()
@@ -38,7 +40,10 @@ public class KeywordService {
     }
 
     @Transactional
-    public void setMyKeywords(Member member, KeywordRequest request) {
+    public void setMyKeywords(Long memberId, KeywordRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> GeneralException.notFound("사용자를 찾을 수 없습니다."));
+
         memberKeywordRepository.deleteAllByMember(member);
 
         List<Keyword> keywords = keywordRepository.findAllById(request.keywordIds());

--- a/src/main/java/ceos/diggindie/domain/keyword/service/KeywordService.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/service/KeywordService.java
@@ -48,8 +48,14 @@ public class KeywordService {
 
         List<Keyword> keywords = keywordRepository.findAllById(request.keywordIds());
 
-        if (keywords.size() != request.keywordIds().size()) {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST, "유효하지 않은 키워드 ID가 포함되어 있습니다.");
+        List<Long> foundIds = keywords.stream().map(Keyword::getId).toList();
+        List<Long> invalidIds = request.keywordIds().stream()
+                .filter(id -> !foundIds.contains(id))
+                .toList();
+
+        if (!invalidIds.isEmpty()) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST,
+                    "유효하지 않은 키워드 ID: " + invalidIds);
         }
 
         List<MemberKeyword> memberKeywords = keywords.stream()

--- a/src/main/java/ceos/diggindie/domain/keyword/service/KeywordService.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/service/KeywordService.java
@@ -1,0 +1,48 @@
+package ceos.diggindie.domain.keyword.service;
+
+import ceos.diggindie.common.exception.GeneralException;
+import ceos.diggindie.common.status.ErrorStatus;
+import ceos.diggindie.domain.keyword.dto.KeywordRequest;
+import ceos.diggindie.domain.keyword.dto.KeywordResponse;
+import ceos.diggindie.domain.keyword.entity.Keyword;
+import ceos.diggindie.domain.keyword.entity.MemberKeyword;
+import ceos.diggindie.domain.keyword.repository.KeywordRepository;
+import ceos.diggindie.domain.keyword.repository.MemberKeywordRepository;
+import ceos.diggindie.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class KeywordService {
+
+    private final KeywordRepository keywordRepository;
+    private final MemberKeywordRepository memberKeywordRepository;
+
+    public List<KeywordResponse> getAllKeywords() {
+        return keywordRepository.findAll().stream()
+                .map(KeywordResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public void saveKeywordPreferences(Member member, KeywordRequest request) {
+        memberKeywordRepository.deleteAllByMember(member);
+
+        List<Keyword> keywords = keywordRepository.findAllById(request.keywordIds());
+
+        if (keywords.size() != request.keywordIds().size()) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "유효하지 않은 키워드 ID가 포함되어 있습니다.");
+        }
+
+        List<MemberKeyword> memberKeywords = keywords.stream()
+                .map(keyword -> MemberKeyword.of(member, keyword))
+                .toList();
+
+        memberKeywordRepository.saveAll(memberKeywords);
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/keyword/service/KeywordService.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/service/KeywordService.java
@@ -29,8 +29,16 @@ public class KeywordService {
                 .toList();
     }
 
+    public List<KeywordResponse> getMyKeywords(Long memberId) {
+        List<MemberKeyword> memberKeywords = memberKeywordRepository.findAllByMemberIdWithKeyword(memberId);
+
+        return memberKeywords.stream()
+                .map(mk -> KeywordResponse.from(mk.getKeyword()))
+                .toList();
+    }
+
     @Transactional
-    public void saveKeywordPreferences(Member member, KeywordRequest request) {
+    public void setMyKeywords(Member member, KeywordRequest request) {
         memberKeywordRepository.deleteAllByMember(member);
 
         List<Keyword> keywords = keywordRepository.findAllById(request.keywordIds());

--- a/src/main/java/ceos/diggindie/domain/member/controller/MemberBandController.java
+++ b/src/main/java/ceos/diggindie/domain/member/controller/MemberBandController.java
@@ -1,0 +1,42 @@
+package ceos.diggindie.domain.member.controller;
+
+import ceos.diggindie.common.config.security.CustomUserDetails;
+import ceos.diggindie.common.exception.GeneralException;
+import ceos.diggindie.common.response.ApiResponse;
+import ceos.diggindie.common.status.SuccessStatus;
+import ceos.diggindie.domain.member.dto.BandPreferenceRequest;
+import ceos.diggindie.domain.member.dto.BandPreferenceResponse;
+import ceos.diggindie.domain.member.service.MemberBandService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberBandController {
+
+    private final MemberBandService memberBandService;
+
+    @PostMapping("/artists/preferences")
+    public ResponseEntity<ApiResponse<Void>> saveBandPreferences(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody BandPreferenceRequest request
+    ) {
+        if (userDetails == null) throw GeneralException.loginRequired();
+
+        memberBandService.saveBandPreferences(userDetails.getUserId(), request);
+        return ApiResponse.onSuccess(SuccessStatus._CREATED, "밴드 취향 설정 API");
+    }
+
+    @GetMapping("/artists/preferences")
+    public ResponseEntity<ApiResponse<BandPreferenceResponse>> getBandPreferences(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) throw GeneralException.loginRequired();
+
+        BandPreferenceResponse response = memberBandService.getBandPreferences(userDetails.getUserId());
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/dto/BandPreferenceRequest.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/BandPreferenceRequest.java
@@ -1,0 +1,10 @@
+package ceos.diggindie.domain.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record BandPreferenceRequest(
+        @NotNull(message = "밴드 ID 리스트는 필수입니다.")
+        List<Long> bands
+) {}

--- a/src/main/java/ceos/diggindie/domain/member/dto/BandPreferenceResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/BandPreferenceResponse.java
@@ -1,0 +1,17 @@
+package ceos.diggindie.domain.member.dto;
+
+import ceos.diggindie.domain.band.dto.BandListResponse;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record BandPreferenceResponse(
+        List<BandListResponse> bands
+) {
+    public static BandPreferenceResponse of(List<BandListResponse> bands) {
+        return BandPreferenceResponse.builder()
+                .bands(bands)
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/entity/MemberBand.java
+++ b/src/main/java/ceos/diggindie/domain/member/entity/MemberBand.java
@@ -4,6 +4,7 @@ import ceos.diggindie.common.entity.BaseEntity;
 import ceos.diggindie.domain.band.entity.Band;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,4 +27,16 @@ public class MemberBand extends BaseEntity {
     @JoinColumn(name = "band_id", nullable = false)
     private Band band;
 
+    @Builder
+    public MemberBand(Member member, Band band) {
+        this.member = member;
+        this.band = band;
+    }
+
+    public static MemberBand of(Member member, Band band) {
+        return MemberBand.builder()
+                .member(member)
+                .band(band)
+                .build();
+    }
 }

--- a/src/main/java/ceos/diggindie/domain/member/entity/MemberBand.java
+++ b/src/main/java/ceos/diggindie/domain/member/entity/MemberBand.java
@@ -1,6 +1,5 @@
 package ceos.diggindie.domain.member.entity;
 
-import ceos.diggindie.common.entity.BaseEntity;
 import ceos.diggindie.domain.band.entity.Band;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -9,33 +8,29 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "member_band")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MemberBand extends BaseEntity {
+public class MemberBand {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "member_band_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    private Long memberId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "band_id", nullable = false)
+    @JoinColumn(name = "band_id")
     private Band band;
 
     @Builder
-    public MemberBand(Member member, Band band) {
-        this.member = member;
+    public MemberBand(Long memberId, Band band) {
+        this.memberId = memberId;
         this.band = band;
     }
 
-    public static MemberBand of(Member member, Band band) {
+    public static MemberBand of(Long memberId, Band band) {
         return MemberBand.builder()
-                .member(member)
+                .memberId(memberId)
                 .band(band)
                 .build();
     }

--- a/src/main/java/ceos/diggindie/domain/member/repository/MemberBandRepository.java
+++ b/src/main/java/ceos/diggindie/domain/member/repository/MemberBandRepository.java
@@ -1,0 +1,21 @@
+package ceos.diggindie.domain.member.repository;
+
+import ceos.diggindie.domain.member.entity.MemberBand;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MemberBandRepository extends JpaRepository<MemberBand, Long> {
+
+    @Modifying
+    @Query("DELETE FROM MemberBand mb WHERE mb.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
+
+    @Query("SELECT mb FROM MemberBand mb " +
+            "JOIN FETCH mb.band " +
+            "WHERE mb.member.id = :memberId")
+    List<MemberBand> findAllByMemberIdWithBand(@Param("memberId") Long memberId);
+}

--- a/src/main/java/ceos/diggindie/domain/member/service/MemberBandService.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/MemberBandService.java
@@ -1,0 +1,60 @@
+package ceos.diggindie.domain.member.service;
+
+import ceos.diggindie.common.exception.GeneralException;
+import ceos.diggindie.domain.band.dto.BandListResponse;
+import ceos.diggindie.domain.band.entity.Band;
+import ceos.diggindie.domain.band.repository.BandRepository;
+import ceos.diggindie.domain.member.dto.BandPreferenceRequest;
+import ceos.diggindie.domain.member.dto.BandPreferenceResponse;
+import ceos.diggindie.domain.member.entity.Member;
+import ceos.diggindie.domain.member.entity.MemberBand;
+import ceos.diggindie.domain.member.repository.MemberBandRepository;
+import ceos.diggindie.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberBandService {
+
+    private final MemberBandRepository memberBandRepository;
+    private final MemberRepository memberRepository;
+    private final BandRepository bandRepository;
+
+    @Transactional
+    public void saveBandPreferences(Long userId, BandPreferenceRequest request) {
+        // 1. 기존 취향 삭제
+        memberBandRepository.deleteAllByMemberId(userId);
+
+        // 2. 멤버 조회
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> GeneralException.notFound("사용자를 찾을 수 없습니다."));
+
+        // 3. 밴드 조회
+        List<Band> bands = bandRepository.findAllById(request.bands());
+        if (bands.size() != request.bands().size()) {
+            throw GeneralException.notFound("일부 밴드를 찾을 수 없습니다.");
+        }
+
+        // 4. 새로운 취향 저장
+        List<MemberBand> memberBands = bands.stream()
+                .map(band -> MemberBand.of(member, band))
+                .toList();
+
+        memberBandRepository.saveAll(memberBands);
+    }
+
+    public BandPreferenceResponse getBandPreferences(Long userId) {
+        List<MemberBand> memberBands = memberBandRepository.findAllByMemberIdWithBand(userId);
+
+        List<BandListResponse> bands = memberBands.stream()
+                .map(mb -> BandListResponse.from(mb.getBand()))
+                .toList();
+
+        return BandPreferenceResponse.of(bands);
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/service/MemberBandService.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/MemberBandService.java
@@ -6,10 +6,8 @@ import ceos.diggindie.domain.band.entity.Band;
 import ceos.diggindie.domain.band.repository.BandRepository;
 import ceos.diggindie.domain.member.dto.BandPreferenceRequest;
 import ceos.diggindie.domain.member.dto.BandPreferenceResponse;
-import ceos.diggindie.domain.member.entity.Member;
 import ceos.diggindie.domain.member.entity.MemberBand;
 import ceos.diggindie.domain.member.repository.MemberBandRepository;
-import ceos.diggindie.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,27 +20,22 @@ import java.util.List;
 public class MemberBandService {
 
     private final MemberBandRepository memberBandRepository;
-    private final MemberRepository memberRepository;
-    private final BandRepository bandRepository;
+    private final BandRepository bandRepository;  // memberRepository 제거
 
     @Transactional
     public void saveBandPreferences(Long userId, BandPreferenceRequest request) {
         // 1. 기존 취향 삭제
         memberBandRepository.deleteAllByMemberId(userId);
 
-        // 2. 멤버 조회
-        Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> GeneralException.notFound("사용자를 찾을 수 없습니다."));
-
-        // 3. 밴드 조회
+        // 2. 밴드 조회 및 검증
         List<Band> bands = bandRepository.findAllById(request.bands());
         if (bands.size() != request.bands().size()) {
             throw GeneralException.notFound("일부 밴드를 찾을 수 없습니다.");
         }
 
-        // 4. 새로운 취향 저장
+        // 3. 새로운 취향 저장 (memberId만 사용)
         List<MemberBand> memberBands = bands.stream()
-                .map(band -> MemberBand.of(member, band))
+                .map(band -> MemberBand.of(userId, band))
                 .toList();
 
         memberBandRepository.saveAll(memberBands);


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #19


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- 밴드 검색 API 추가(GET /artists) + 검색 성능 최적화
  - 밴드명 + 키워드 기반 검색 지원 (`ILIKE %query%`)
  - JOIN FETCH + countQuery 분리해두었습니다.
  - 검색 성능 개선 관련해서 PostgreSQL pg_trgm 확장 도입 및 GIN index 추가해두었습니다~!

- POST /my/artists, GET /my/artists (스크랩한 아티스트 조회 및 저장)
- POST /artists/preferences, GET /artists/preferences (밴드 취향 조회 및 저장)
- GET /keywords (전체 키워드 조회)
- GET /my/keywords, POST /my/keywords (내 키워드 설정, 조회)
- GET /my/concerts (스크랩한 공연 조회)

## ⚠️ PR 특이 사항

- BandScrapService.saveBandScraps()에서 findAllById() 사용 중이라 요청 bandIds 일부가 없으면 현재 누락될 수 있는 상황이라 `(bands.size != request.bandIds.size)`와 같이 검증으로 막을지 논의가 필요합니다.
- BandRepository.searchBands()가 FETCH JOIN + pagination 구조라서 데이터 규모가 커졌을 때 성능/카운트쿼리 정확성 확인이 필요합니다.
- 스크랩/키워드/취향 저장 API는 현재 replace 방식(기존 전체 삭제 후 재저장) 으로 동작합니다. patch로 구현하지 않아도 되겠죠?

## 📚 Reference


### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
