### PR TITLE
[FEAT] 스포티파이 곡 및 앨범 저장 api

### DIFF
--- a/src/main/java/ceos/diggindie/domain/band/entity/Album.java
+++ b/src/main/java/ceos/diggindie/domain/band/entity/Album.java
@@ -3,6 +3,7 @@ package ceos.diggindie.domain.band.entity;
 import ceos.diggindie.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,8 +24,17 @@ public class Album extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String title;
 
-    @Column(name = "album_image", length = 200)
+    @Column(name = "album_image", length = 300)
     private String albumImage;
+
+    @Column(name = "spotify_id", length = 100)
+    private String spotifyId;
+
+    @Column(name = "release_date", length = 20)
+    private String releaseDate;
+
+    @Column(name = "album_type", length = 20)
+    private String albumType;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "band_id", nullable = false)
@@ -33,4 +43,14 @@ public class Album extends BaseEntity {
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Music> musics = new ArrayList<>();
 
+    @Builder
+    public Album(String title, String albumImage, String spotifyId,
+                 String releaseDate, String albumType, Band band) {
+        this.title = title;
+        this.albumImage = albumImage;
+        this.spotifyId = spotifyId;
+        this.releaseDate = releaseDate;
+        this.albumType = albumType;
+        this.band = band;
+    }
 }

--- a/src/main/java/ceos/diggindie/domain/band/entity/Music.java
+++ b/src/main/java/ceos/diggindie/domain/band/entity/Music.java
@@ -3,6 +3,7 @@ package ceos.diggindie.domain.band.entity;
 import ceos.diggindie.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,17 +18,37 @@ public class Music extends BaseEntity {
     @Column(name = "music_id")
     private Long id;
 
-    @Column(name = "music_name", nullable = false, length = 50)
-    private String musicName;
+    @Column(name = "music_name", nullable = false, length = 150)
+    private String title;
 
-    @Column(name = "main_music")
-    private Boolean mainMusic;
+    @Column(name = "track_number")
+    private Integer trackNumber;
 
-    @Column(name = "music_url", length = 100)
-    private String musicUrl;
+    @Column(name = "duration_ms")
+    private Integer durationMs;
+
+    @Column(name = "preview_url", length = 300)
+    private String previewUrl;
+
+    @Column(name = "spotify_url", length = 300)
+    private String spotifyUrl;
+
+    @Column(name = "spotify_id", length = 100)
+    private String spotifyId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "album_id", nullable = false)
     private Album album;
 
+    @Builder
+    public Music(String title, Integer trackNumber, Integer durationMs,
+                 String previewUrl, String spotifyUrl, String spotifyId, Album album) {
+        this.title = title;
+        this.trackNumber = trackNumber;
+        this.durationMs = durationMs;
+        this.previewUrl = previewUrl;
+        this.spotifyUrl = spotifyUrl;
+        this.spotifyId = spotifyId;
+        this.album = album;
+    }
 }

--- a/src/main/java/ceos/diggindie/domain/band/repository/AlbumRepository.java
+++ b/src/main/java/ceos/diggindie/domain/band/repository/AlbumRepository.java
@@ -1,0 +1,11 @@
+package ceos.diggindie.domain.band.repository;
+
+import ceos.diggindie.domain.band.entity.Album;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AlbumRepository extends JpaRepository<Album, Long> {
+    boolean existsBySpotifyId(String spotifyId);
+    Optional<Album> findBySpotifyId(String spotifyId);
+}

--- a/src/main/java/ceos/diggindie/domain/band/repository/MusicRepository.java
+++ b/src/main/java/ceos/diggindie/domain/band/repository/MusicRepository.java
@@ -1,0 +1,8 @@
+package ceos.diggindie.domain.band.repository;
+
+import ceos.diggindie.domain.band.entity.Music;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MusicRepository extends JpaRepository<Music, Long> {
+    boolean existsBySpotifyId(String spotifyId);
+}

--- a/src/main/java/ceos/diggindie/domain/spotify/controller/SpotifyController.java
+++ b/src/main/java/ceos/diggindie/domain/spotify/controller/SpotifyController.java
@@ -5,12 +5,14 @@ import ceos.diggindie.common.response.Response;
 import ceos.diggindie.domain.spotify.dto.SpotifySearchRequest;
 import ceos.diggindie.domain.spotify.dto.SpotifySearchResponse;
 import ceos.diggindie.domain.spotify.dto.SpotifyTokenResponse;
+import ceos.diggindie.domain.spotify.service.SpotifyImportService;
 import ceos.diggindie.domain.spotify.service.SpotifyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,11 +20,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class SpotifyController {
 
     private final SpotifyService spotifyService;
+    private final SpotifyImportService spotifyImportService;
 
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/api/admin/spotify/auth")
     public ResponseEntity<Response<?>> spotifyAuth() {
-
         Response<SpotifyTokenResponse> response = Response.of(
                 SuccessCode.GET_SUCCESS,
                 true,
@@ -33,8 +35,7 @@ public class SpotifyController {
 
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/api/admin/spotify/search")
-    public ResponseEntity<Response<?>> spotifySearch(
-            SpotifySearchRequest request) {
+    public ResponseEntity<Response<?>> spotifySearch(SpotifySearchRequest request) {
         Response<SpotifySearchResponse> response = Response.of(
                 SuccessCode.GET_SUCCESS,
                 true,
@@ -43,4 +44,22 @@ public class SpotifyController {
         return ResponseEntity.ok().body(response);
     }
 
+    // 전체 밴드 앨범/곡 Import
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/api/admin/spotify/import-albums")
+    public ResponseEntity<Response<String>> importAllAlbums() {
+        spotifyImportService.importAllBandsAlbums();
+        return ResponseEntity.ok().body(
+                Response.of(SuccessCode.INSERT_SUCCESS, true, "앨범/곡 Import 완료")
+        );
+    }
+
+    // 특정 밴드 앨범/곡 Import (bandId로)
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/api/admin/spotify/import-albums/{bandId}")
+    public ResponseEntity<Response<String>> importBandAlbums(@PathVariable Long bandId) {
+        return ResponseEntity.ok().body(
+                Response.of(SuccessCode.INSERT_SUCCESS, true, "밴드 앨범/곡 Import 완료")
+        );
+    }
 }

--- a/src/main/java/ceos/diggindie/domain/spotify/dto/SpotifyAlbumsResponse.java
+++ b/src/main/java/ceos/diggindie/domain/spotify/dto/SpotifyAlbumsResponse.java
@@ -1,0 +1,32 @@
+package ceos.diggindie.domain.spotify.dto;
+
+import java.util.List;
+
+public record SpotifyAlbumsResponse(
+        String href,
+        int limit,
+        String next,
+        int offset,
+        int total,
+        List<AlbumItem> items
+) {
+    public record AlbumItem(
+            String id,
+            String name,
+            String album_type,
+            String release_date,
+            int total_tracks,
+            List<Image> images,
+            ExternalUrls external_urls
+    ) {}
+
+    public record Image(
+            String url,
+            int height,
+            int width
+    ) {}
+
+    public record ExternalUrls(
+            String spotify
+    ) {}
+}

--- a/src/main/java/ceos/diggindie/domain/spotify/dto/SpotifyTracksResponse.java
+++ b/src/main/java/ceos/diggindie/domain/spotify/dto/SpotifyTracksResponse.java
@@ -1,0 +1,25 @@
+package ceos.diggindie.domain.spotify.dto;
+
+import java.util.List;
+
+public record SpotifyTracksResponse(
+        String href,
+        int limit,
+        String next,
+        int offset,
+        int total,
+        List<TrackItem> items
+) {
+    public record TrackItem(
+            String id,
+            String name,
+            int track_number,
+            int duration_ms,
+            String preview_url,
+            ExternalUrls external_urls
+    ) {}
+
+    public record ExternalUrls(
+            String spotify
+    ) {}
+}

--- a/src/main/java/ceos/diggindie/domain/spotify/service/AlbumSaveService.java
+++ b/src/main/java/ceos/diggindie/domain/spotify/service/AlbumSaveService.java
@@ -1,0 +1,76 @@
+package ceos.diggindie.domain.spotify.service;
+
+import ceos.diggindie.domain.band.entity.Album;
+import ceos.diggindie.domain.band.entity.Band;
+import ceos.diggindie.domain.band.entity.Music;
+import ceos.diggindie.domain.band.repository.AlbumRepository;
+import ceos.diggindie.domain.band.repository.MusicRepository;
+import ceos.diggindie.domain.spotify.dto.SpotifyAlbumsResponse;
+import ceos.diggindie.domain.spotify.dto.SpotifyTracksResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AlbumSaveService {
+
+    private final AlbumRepository albumRepository;
+    private final MusicRepository musicRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveAlbumWithTracks(SpotifyAlbumsResponse.AlbumItem spotifyAlbum,
+                                    List<SpotifyTracksResponse.TrackItem> tracks,
+                                    Band band) {
+
+        if (albumRepository.existsBySpotifyId(spotifyAlbum.id())) {
+            log.debug("이미 존재하는 앨범: {}", spotifyAlbum.name());
+            return;
+        }
+
+        String albumImage = spotifyAlbum.images().stream()
+                .findFirst()
+                .map(SpotifyAlbumsResponse.Image::url)
+                .orElse(null);
+
+        Album album = Album.builder()
+                .band(band)
+                .title(spotifyAlbum.name())
+                .spotifyId(spotifyAlbum.id())
+                .releaseDate(spotifyAlbum.release_date())
+                .albumType(spotifyAlbum.album_type())
+                .albumImage(albumImage)
+                .build();
+
+        albumRepository.save(album);
+
+        for (SpotifyTracksResponse.TrackItem track : tracks) {
+            if (musicRepository.existsBySpotifyId(track.id())) {
+                continue;
+            }
+
+            String spotifyUrl = track.external_urls() != null
+                    ? track.external_urls().spotify()
+                    : null;
+
+            Music music = Music.builder()
+                    .album(album)
+                    .title(track.name())
+                    .trackNumber(track.track_number())
+                    .durationMs(track.duration_ms())
+                    .previewUrl(track.preview_url())
+                    .spotifyUrl(spotifyUrl)
+                    .spotifyId(track.id())
+                    .build();
+
+            musicRepository.save(music);
+        }
+
+        log.debug("앨범 저장 완료: {} (트랙 {}개)", spotifyAlbum.name(), tracks.size());
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/spotify/service/SpotifyImportService.java
+++ b/src/main/java/ceos/diggindie/domain/spotify/service/SpotifyImportService.java
@@ -1,0 +1,76 @@
+package ceos.diggindie.domain.spotify.service;
+
+import ceos.diggindie.domain.band.entity.Band;
+import ceos.diggindie.domain.band.repository.BandRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SpotifyImportService {
+
+    private final SpotifyService spotifyService;
+    private final BandRepository bandRepository;
+    private final AlbumSaveService albumSaveService;
+
+    /**
+     * 모든 밴드의 앨범/곡 데이터 import
+     */
+    @Transactional
+    public void importAllBandsAlbums() {
+        List<Band> bands = bandRepository.findAll();
+
+        int total = bands.size();
+        int completed = 0;
+        int failed = 0;
+
+        log.info("========== 앨범/곡 Import 시작 (총 {}개 밴드) ==========", total);
+
+        for (Band band : bands) {
+            try {
+                importBandAlbums(band);
+                completed++;
+                log.info("[{}/{}] {} 완료", completed, total, band.getBandName());
+
+                // Rate limit 방지
+                Thread.sleep(100);
+            } catch (Exception e) {
+                failed++;
+                log.error("[실패] {} - {}", band.getBandName(), e.getMessage());
+            }
+        }
+
+        log.info("========== Import 완료: 성공 {}, 실패 {} ==========", completed, failed);
+    }
+
+    /**
+     * 단일 밴드의 앨범/곡 import
+     */
+    // @Transactional save service에서 처리함
+    public void importBandAlbums(Band band) {
+        if (band.getSpotifyId() == null) {
+            log.warn("Spotify ID 없음: {}", band.getBandName());
+            return;
+        }
+
+        try {
+            var albumsResponse = spotifyService.getArtistAlbums(band.getSpotifyId(), 10);
+
+            for (var spotifyAlbum : albumsResponse.items()) {
+                try {
+                    var tracksResponse = spotifyService.getAlbumTracks(spotifyAlbum.id());
+                    albumSaveService.saveAlbumWithTracks(spotifyAlbum, tracksResponse.items(), band);
+                } catch (Exception e) {
+                    log.error("앨범 저장 실패: {} - {}", spotifyAlbum.name(), e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            log.error("밴드 앨범 조회 실패: {} - {}", band.getBandName(), e.getMessage());
+        }
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/spotify/service/SpotifyService.java
+++ b/src/main/java/ceos/diggindie/domain/spotify/service/SpotifyService.java
@@ -1,13 +1,14 @@
 package ceos.diggindie.domain.spotify.service;
 
+import ceos.diggindie.domain.spotify.dto.SpotifyAlbumsResponse;
 import ceos.diggindie.domain.spotify.dto.SpotifySearchRequest;
 import ceos.diggindie.domain.spotify.dto.SpotifySearchResponse;
 import ceos.diggindie.domain.spotify.dto.SpotifyTokenResponse;
+import ceos.diggindie.domain.spotify.dto.SpotifyTracksResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -26,20 +27,39 @@ public class SpotifyService {
 
     private final RestClient restClient;
 
+    // 토큰 캐싱
+    private String cachedToken;
+    private long tokenExpiryTime;
+
+    public String getAccessToken() {
+        // 토큰이 유효하면 캐시된 토큰 반환
+        if (cachedToken != null && System.currentTimeMillis() < tokenExpiryTime) {
+            return cachedToken;
+        }
+
+        SpotifyTokenResponse response = getSpotifyToken();
+        if (response != null && response.accessToken() != null) {
+            cachedToken = response.accessToken();
+            // 만료 1분 전에 갱신하도록 설정
+            tokenExpiryTime = System.currentTimeMillis() + (response.expiresIn() - 60) * 1000L;
+        }
+        return cachedToken;
+    }
+
     public SpotifyTokenResponse getSpotifyToken() {
 
-         MultiValueMap<String, String> payload = new LinkedMultiValueMap<>();
-         payload.add("grant_type", "client_credentials");
-         payload.add("client_id", CLIENT_ID);
-         payload.add("client_secret", CLIENT_SECRET);
+        MultiValueMap<String, String> payload = new LinkedMultiValueMap<>();
+        payload.add("grant_type", "client_credentials");
+        payload.add("client_id", CLIENT_ID);
+        payload.add("client_secret", CLIENT_SECRET);
 
-         SpotifyTokenResponse response = restClient
-                    .post()
-                    .uri("https://accounts.spotify.com/api/token")
-                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                    .body(payload)
-                    .retrieve()
-                    .body(SpotifyTokenResponse.class);
+        SpotifyTokenResponse response = restClient
+                .post()
+                .uri("https://accounts.spotify.com/api/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(payload)
+                .retrieve()
+                .body(SpotifyTokenResponse.class);
 
         if (response == null || response.accessToken() == null) {
             log.info("Spotify access token 발급 실패");
@@ -50,12 +70,9 @@ public class SpotifyService {
         return response;
     }
 
-
-
     public SpotifySearchResponse searchSpotify(SpotifySearchRequest request) {
 
-        SpotifyTokenResponse tokenResponse = getSpotifyToken();
-        String accessToken = tokenResponse.accessToken();
+        String accessToken = getAccessToken();
         String query = request.query();
 
         SpotifySearchResponse response = restClient
@@ -77,6 +94,65 @@ public class SpotifyService {
             log.info("Spotify 검색 실패");
         } else {
             log.info("Spotify 검색 성공");
+        }
+
+        return response;
+    }
+
+    /**
+     * 아티스트의 앨범 목록 조회
+     */
+    public SpotifyAlbumsResponse getArtistAlbums(String artistId, int limit) {
+
+        String accessToken = getAccessToken();
+
+        SpotifyAlbumsResponse response = restClient
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .host("api.spotify.com")
+                        .path("/v1/artists/{artistId}/albums")
+                        .queryParam("include_groups", "album,single")
+                        .queryParam("market", "KR")
+                        .queryParam("limit", limit)
+                        .build(artistId))
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .body(SpotifyAlbumsResponse.class);
+
+        if (response == null) {
+            log.warn("아티스트 앨범 조회 실패: {}", artistId);
+        } else {
+            log.info("아티스트 앨범 조회 성공: {} ({}개)", artistId, response.items().size());
+        }
+
+        return response;
+    }
+
+    /**
+     * 앨범의 트랙 목록 조회
+     */
+    public SpotifyTracksResponse getAlbumTracks(String albumId) {
+
+        String accessToken = getAccessToken();
+
+        SpotifyTracksResponse response = restClient
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .host("api.spotify.com")
+                        .path("/v1/albums/{albumId}/tracks")
+                        .queryParam("market", "KR")
+                        .queryParam("limit", 50)
+                        .build(albumId))
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .body(SpotifyTracksResponse.class);
+
+        if (response == null) {
+            log.warn("앨범 트랙 조회 실패: {}", albumId);
+        } else {
+            log.info("앨범 트랙 조회 성공: {} ({}곡)", albumId, response.items().size());
         }
 
         return response;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,3 +39,7 @@ jwt:
 openai:
   client-id: ${OPENAI_API_KEY}
   model: ${OPENAI_MODEL}
+
+spotify:
+  client-id: ${SPOTIFY_CLIENT_ID}
+  client-secret: ${SPOTIFY_CLIENT_SECRET}


### PR DESCRIPTION
## 🛰️ Issue Number
close #24

## 🪐 작업 내용

### 1. 엔티티 수정/생성
- **Album 엔티티**: `spotifyId`, `releaseDate`, `albumType`, `albumImage` 필드 추가


### 2. Repository 추가
- `AlbumRepository`: `existsBySpotifyId()`, `findBySpotifyId()` 
- `MusicRepository`: `existsBySpotifyId()`

### 3. Spotify API 연동
- `SpotifyAlbumsResponse`: 아티스트 앨범 목록 응답 DTO
- `SpotifyTracksResponse`: 앨범 트랙 목록 응답 DTO
- `SpotifyService`: `getArtistAlbums()`, `getAlbumTracks()` 메서드 추가

### 4. Import 서비스
- `AlbumSaveService`: 앨범/트랙 저장 (별도 트랜잭션으로 분리)
- `SpotifyImportService`: 전체 밴드 Import 로직

### 5. API 엔드포인트
| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | `/api/admin/spotify/import-albums` | 전체 밴드 앨범/곡 Import |
| POST | `/api/admin/spotify/import-albums/{bandId}` | 특정 밴드 앨범/곡 Import |


## ⚠️ PR 특이 사항
- Spotify API Rate Limit (429) 발생 시 30분 후 재실행하면 실패한 부분부터 이어서 처리하도록 함 !!
- `existsBySpotifyId()` 체크로 중복 저장 방지
- 트랜잭션 분리(`REQUIRES_NEW`)로 개별 앨범 저장 실패 시에도 다른 앨범 저장 계속 진행

## 📚 Reference


### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?