### PR TITLE
[FIX] 쿠키 세팅 변경

### DIFF
--- a/src/main/java/ceos/diggindie/domain/member/service/AuthService.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/AuthService.java
@@ -87,7 +87,7 @@ public class AuthService {
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .httpOnly(true)
                 .secure(true)
-                .sameSite("Strict")
+                .sameSite("None")
                 .path("/")
                 .maxAge(maxAge)
                 .build();


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #48 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- 쿠키 세팅 시 sameSite 설정을 None으로 변경하였습니다.


## ⚠️ PR 특이 사항

`SameSite`는 “이 쿠키가 cross-site 요청에 포함될 수 있는가?”를 브라우저가 결정하기 위한 쿠키 속성이며,
→ CSRF 공격을 줄이기 위한 브라우저 차원의 방어 장치이다.

서버는 쿠키를 발급할 때 SameSite 정책을 명시하고
브라우저는 이후 요청 시 해당 정책을 기준으로 쿠키를 포함/차단한다

1. SameSite=None
```
브라우저는 요청이 same-site 인지 cross-site 인지와 무관하게
쿠키를 요청에 포함할 수 있다.

단, SameSite=None 쿠키는 반드시 Secure=true 여야 하며
HTTPS 환경에서만 동작한다.
```

2. SameSite=Lax
```
cross-site 요청 중에서도 "안전한 top-level navigation" 에서만 쿠키를 포함한다.
ex) 사용자가 링크 클릭, 주소창 직접 입력, <a href="..."> 로 이동

cross-site Post 요청, axios, fetch 요청 등에서는 쿠키가 담기지 않음
```

3. SameSite=Strict
```
SameSite=Strict 설정 시,
요청이 완전히 same-site 인 경우에만 쿠키를 포함

따라서 외부 사이트에서 본 사이트로 들어오는 요청에서 로그인이 풀리는 현상 발생
ex) google.com → diggindie.com (Cross-Site)
```


## 📚 Reference
https://web.dev/articles/samesite-cookies-explained?hl=ko
https://dev-cat.tistory.com/67


### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 포스트맨에서 결과값을 제대로 확인했나요?
- [ ] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
