### PR TITLE
[REFACTOR] ErrorCode 및 Exception 분리

### DIFF
--- a/src/main/java/ceos/diggindie/common/code/BusinessErrorCode.java
+++ b/src/main/java/ceos/diggindie/common/code/BusinessErrorCode.java
@@ -1,0 +1,33 @@
+package ceos.diggindie.common.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BusinessErrorCode implements Code {
+
+    // ==================== 회원 ====================
+    MEMBER_NOT_FOUND(404, "회원을 찾을 수 없습니다."),
+    DUPLICATE_EMAIL(409, "이미 사용 중인 이메일입니다."),
+    DUPLICATE_NICKNAME(409, "이미 사용 중인 닉네임입니다."),
+
+    // ==================== 아티스트 ====================
+    ARTIST_NOT_FOUND(404, "아티스트를 찾을 수 없습니다."),
+
+    // ==================== 앨범 ====================
+    ALBUM_NOT_FOUND(404, "앨범을 찾을 수 없습니다."),
+
+    // ==================== 좋아요 ====================
+    ALREADY_LIKED(409, "이미 좋아요를 눌렀습니다."),
+    LIKE_NOT_FOUND(404, "좋아요 기록을 찾을 수 없습니다."),
+
+    // ==================== 스크랩 ====================
+    ALREADY_SCRAPPED(409, "이미 스크랩한 항목입니다."),
+    SCRAP_NOT_FOUND(404, "스크랩 기록을 찾을 수 없습니다."),
+
+    ;
+
+    private final int statusCode;
+    private final String message;
+}

--- a/src/main/java/ceos/diggindie/common/code/GeneralErrorCode.java
+++ b/src/main/java/ceos/diggindie/common/code/GeneralErrorCode.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum ErrorCode implements Code {
+public enum GeneralErrorCode implements Code {
 
     // ==================== 공통 에러 ====================
     INTERNAL_SERVER_ERROR(500, "서버 에러, 관리자에게 문의 바랍니다."),
@@ -22,25 +22,6 @@ public enum ErrorCode implements Code {
     INVALID_TOKEN(401, "유효하지 않은 토큰입니다."),
     TOKEN_EXPIRED(401, "토큰이 만료되었습니다."),
     REFRESH_TOKEN_EXPIRED(401, "리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요."),
-
-    // ==================== 회원 ====================
-    MEMBER_NOT_FOUND(404, "회원을 찾을 수 없습니다."),
-    DUPLICATE_EMAIL(409, "이미 사용 중인 이메일입니다."),
-    DUPLICATE_NICKNAME(409, "이미 사용 중인 닉네임입니다."),
-
-    // ==================== 아티스트 ====================
-    ARTIST_NOT_FOUND(404, "아티스트를 찾을 수 없습니다."),
-
-    // ==================== 앨범 ====================
-    ALBUM_NOT_FOUND(404, "앨범을 찾을 수 없습니다."),
-
-    // ==================== 좋아요 ====================
-    ALREADY_LIKED(409, "이미 좋아요를 눌렀습니다."),
-    LIKE_NOT_FOUND(404, "좋아요 기록을 찾을 수 없습니다."),
-
-    // ==================== 스크랩 ====================
-    ALREADY_SCRAPPED(409, "이미 스크랩한 항목입니다."),
-    SCRAP_NOT_FOUND(404, "스크랩 기록을 찾을 수 없습니다."),
 
     // ==================== 검색 ====================
     INVALID_SEARCH_KEYWORD(400, "검색어는 공백일 수 없습니다."),

--- a/src/main/java/ceos/diggindie/common/code/GeneralErrorCode.java
+++ b/src/main/java/ceos/diggindie/common/code/GeneralErrorCode.java
@@ -13,12 +13,13 @@ public enum GeneralErrorCode implements Code {
     UNAUTHORIZED(401, "인증이 필요합니다."),
     FORBIDDEN(403, "접근 권한이 없습니다."),
     NOT_FOUND(404, "리소스를 찾을 수 없습니다."),
+    METHOD_NOT_ALLOWED(405, "지원하지 않는 HTTP 메서드입니다."),
+    UNSUPPORTED_MEDIA_TYPE(415, "지원하지 않는 미디어 타입입니다."),
 
     // ==================== 입력값 검증 ====================
     VALIDATION_ERROR(400, "입력값이 올바르지 않습니다."),
 
     // ==================== 인증/로그인 ====================
-    LOGIN_REQUIRED(401, "로그인이 필요합니다."),
     INVALID_TOKEN(401, "유효하지 않은 토큰입니다."),
     TOKEN_EXPIRED(401, "토큰이 만료되었습니다."),
     REFRESH_TOKEN_EXPIRED(401, "리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요."),

--- a/src/main/java/ceos/diggindie/common/config/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/ceos/diggindie/common/config/security/jwt/JwtAccessDeniedHandler.java
@@ -1,6 +1,6 @@
 package ceos.diggindie.common.config.security.jwt;
 
-import ceos.diggindie.common.code.ErrorCode;
+import ceos.diggindie.common.code.GeneralErrorCode;
 import ceos.diggindie.common.response.Response;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
@@ -29,7 +29,7 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        Response<Void> body = Response.fail(ErrorCode.FORBIDDEN);
+        Response<Void> body = Response.fail(GeneralErrorCode.FORBIDDEN);
         response.getWriter().write(objectMapper.writeValueAsString(body));
         response.getWriter().flush();
     }

--- a/src/main/java/ceos/diggindie/common/config/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/ceos/diggindie/common/config/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,6 +1,6 @@
 package ceos.diggindie.common.config.security.jwt;
 
-import ceos.diggindie.common.code.ErrorCode;
+import ceos.diggindie.common.code.GeneralErrorCode;
 import ceos.diggindie.common.response.Response;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
@@ -29,7 +29,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        Response<Void> body = Response.fail(ErrorCode.UNAUTHORIZED);
+        Response<Void> body = Response.fail(GeneralErrorCode.UNAUTHORIZED);
         response.getWriter().write(objectMapper.writeValueAsString(body));
         response.getWriter().flush();
 

--- a/src/main/java/ceos/diggindie/common/exception/BusinessException.java
+++ b/src/main/java/ceos/diggindie/common/exception/BusinessException.java
@@ -1,0 +1,21 @@
+package ceos.diggindie.common.exception;
+
+
+import ceos.diggindie.common.code.BusinessErrorCode;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final BusinessErrorCode businessErrorCode;
+
+    public BusinessException(BusinessErrorCode businessErrorCode) {
+        super(businessErrorCode.getMessage());
+        this.businessErrorCode = businessErrorCode;
+    }
+
+    public BusinessException(BusinessErrorCode businessErrorCode, String message) {
+        super(message);
+        this.businessErrorCode = businessErrorCode;
+    }
+}

--- a/src/main/java/ceos/diggindie/common/exception/GeneralException.java
+++ b/src/main/java/ceos/diggindie/common/exception/GeneralException.java
@@ -1,20 +1,20 @@
 package ceos.diggindie.common.exception;
 
 
-import ceos.diggindie.common.code.ErrorCode;
+import ceos.diggindie.common.code.GeneralErrorCode;
 import lombok.Getter;
 
 @Getter
 public class GeneralException extends RuntimeException {
 
-    private final ErrorCode errorCode;
+    private final GeneralErrorCode errorCode;
 
-    public GeneralException(ErrorCode errorCode, String message) {
+    public GeneralException(GeneralErrorCode errorCode, String message) {
         super(message);
         this.errorCode = errorCode;
     }
 
     public static GeneralException notFound(String message) {
-        return new GeneralException(ErrorCode.NOT_FOUND, message);
+        return new GeneralException(GeneralErrorCode.NOT_FOUND, message);
     }
 }

--- a/src/main/java/ceos/diggindie/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ceos/diggindie/common/exception/GlobalExceptionHandler.java
@@ -7,7 +7,11 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -19,48 +23,7 @@ import java.util.stream.Collectors;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<Response<Void>> handleConstraintViolation(ConstraintViolationException e) {
-
-        GeneralErrorCode errorCode = GeneralErrorCode.VALIDATION_ERROR;
-        String detailedErrors = e.getConstraintViolations().stream()
-                .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
-                .collect(Collectors.joining(", "));
-        log.warn("ConstraintViolationException - Validation errors: [{}]", detailedErrors);
-
-        return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
-    }
-
-    // @RequestBody 검증 실패
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Response<Void>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
-
-        GeneralErrorCode errorCode = GeneralErrorCode.VALIDATION_ERROR;
-        String detailedErrors = e.getBindingResult().getFieldErrors().stream()
-                .map(error -> error.getField() + ": " + error.getDefaultMessage())
-                .collect(Collectors.joining(", "));
-        log.warn("MethodArgumentNotValidException - Field errors: [{}]", detailedErrors);
-
-        return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
-    }
-
-    // 리소스를 찾을 수 없음
-    @ExceptionHandler(NoResourceFoundException.class)
-    public ResponseEntity<Response<Void>> handleNoResourceFound(NoResourceFoundException e) {
-        GeneralErrorCode errorCode = GeneralErrorCode.NOT_FOUND;
-        log.warn("NoResourceFoundException: {}", e.getMessage());
-
-        return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
-    }
-
-    // 타입 변환 실패 (PathVariable, RequestParam 등)
-    @ExceptionHandler({MethodArgumentTypeMismatchException.class, ConversionFailedException.class})
-    public ResponseEntity<Response<Void>> handleTypeMismatch(Exception e) {
-        GeneralErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
-        log.warn("TypeMismatchException: {}", e.getMessage());
-
-        return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
-    }
+    // ==================== 커스텀 예외 ====================
 
     // 비즈니스 예외
     @ExceptionHandler(BusinessException.class)
@@ -80,10 +43,90 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
     }
 
+    // ==================== Validation 예외 ====================
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Response<Void>> handleConstraintViolation(ConstraintViolationException e) {
+        GeneralErrorCode errorCode = GeneralErrorCode.VALIDATION_ERROR;
+        String detailedErrors = e.getConstraintViolations().stream()
+                .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+                .collect(Collectors.joining(", "));
+        log.warn("ConstraintViolationException - Validation errors: [{}]", detailedErrors);
+
+        return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
+    }
+
+    // @RequestBody 검증 실패
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Response<Void>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        GeneralErrorCode errorCode = GeneralErrorCode.VALIDATION_ERROR;
+        String detailedErrors = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        log.warn("MethodArgumentNotValidException - Field errors: [{}]", detailedErrors);
+
+        return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
+    }
+
+    // ==================== HTTP 요청 예외 ====================
+
+    // 리소스를 찾을 수 없음
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<Response<Void>> handleNoResourceFound(NoResourceFoundException e) {
+        GeneralErrorCode errorCode = GeneralErrorCode.NOT_FOUND;
+        log.warn("NoResourceFoundException: {}", e.getMessage());
+
+        return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
+    }
+
+    // 지원하지 않는 HTTP 메서드
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<Response<Void>> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+        GeneralErrorCode errorCode = GeneralErrorCode.METHOD_NOT_ALLOWED;
+        log.warn("HttpRequestMethodNotSupportedException: {}", e.getMessage());
+
+        return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
+    }
+
+    // 지원하지 않는 Content-Type
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<Response<Void>> handleMediaTypeNotSupported(HttpMediaTypeNotSupportedException e) {
+        GeneralErrorCode errorCode = GeneralErrorCode.UNSUPPORTED_MEDIA_TYPE;
+        log.warn("HttpMediaTypeNotSupportedException: {}", e.getMessage());
+
+        return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
+    }
+
+    // 타입 변환 실패
+    @ExceptionHandler({MethodArgumentTypeMismatchException.class, ConversionFailedException.class})
+    public ResponseEntity<Response<Void>> handleTypeMismatch(Exception e) {
+        GeneralErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
+        log.warn("TypeMismatchException: {}", e.getMessage());
+
+        return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
+    }
+
+    // 필수 파라미터 누락
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<Response<Void>> handleMissingParameter(MissingServletRequestParameterException e) {
+        GeneralErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
+        log.warn("MissingServletRequestParameterException: {}", e.getMessage());
+
+        return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
+    }
+
+    // JSON 파싱 실패
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<Response<Void>> handleMessageNotReadable(HttpMessageNotReadableException e) {
+        GeneralErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
+        log.warn("HttpMessageNotReadableException: {}", e.getMessage());
+
+        return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
+    }
+
     // 그 외 모든 예외
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Response<Void>> handleException(Exception e) {
-
         GeneralErrorCode errorCode = GeneralErrorCode.INTERNAL_SERVER_ERROR;
         log.error("Unhandled Exception: ", e);
 

--- a/src/main/java/ceos/diggindie/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ceos/diggindie/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package ceos.diggindie.common.exception;
 
-import ceos.diggindie.common.code.ErrorCode;
+import ceos.diggindie.common.code.BusinessErrorCode;
+import ceos.diggindie.common.code.GeneralErrorCode;
 import ceos.diggindie.common.response.Response;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +22,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<Response<Void>> handleConstraintViolation(ConstraintViolationException e) {
 
-        ErrorCode errorCode = ErrorCode.VALIDATION_ERROR;
+        GeneralErrorCode errorCode = GeneralErrorCode.VALIDATION_ERROR;
         String detailedErrors = e.getConstraintViolations().stream()
                 .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
                 .collect(Collectors.joining(", "));
@@ -34,7 +35,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Response<Void>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
 
-        ErrorCode errorCode = ErrorCode.VALIDATION_ERROR;
+        GeneralErrorCode errorCode = GeneralErrorCode.VALIDATION_ERROR;
         String detailedErrors = e.getBindingResult().getFieldErrors().stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .collect(Collectors.joining(", "));
@@ -46,7 +47,7 @@ public class GlobalExceptionHandler {
     // 리소스를 찾을 수 없음
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<Response<Void>> handleNoResourceFound(NoResourceFoundException e) {
-        ErrorCode errorCode = ErrorCode.NOT_FOUND;
+        GeneralErrorCode errorCode = GeneralErrorCode.NOT_FOUND;
         log.warn("NoResourceFoundException: {}", e.getMessage());
 
         return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
@@ -55,24 +56,35 @@ public class GlobalExceptionHandler {
     // 타입 변환 실패 (PathVariable, RequestParam 등)
     @ExceptionHandler({MethodArgumentTypeMismatchException.class, ConversionFailedException.class})
     public ResponseEntity<Response<Void>> handleTypeMismatch(Exception e) {
-        ErrorCode errorCode = ErrorCode.BAD_REQUEST;
+        GeneralErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
         log.warn("TypeMismatchException: {}", e.getMessage());
 
         return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
     }
 
-    // 커스텀 비즈니스 예외
-    // 추후 에러 핸들링 세팅에서 수정해주시길 바랍니다!
+    // 비즈니스 예외
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<Response<Void>> handleBusinessException(BusinessException e) {
+        BusinessErrorCode errorCode = e.getBusinessErrorCode();
+        log.warn("BusinessException: {} - {}", errorCode.name(), e.getMessage());
+
+        return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
+    }
+
+    // 일반 예외
     @ExceptionHandler(GeneralException.class)
     public ResponseEntity<Response<Void>> handleGeneralException(GeneralException e) {
-        return null;
+        GeneralErrorCode errorCode = e.getErrorCode();
+        log.warn("GeneralException: {} - {}", errorCode.name(), e.getMessage());
+
+        return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));
     }
 
     // 그 외 모든 예외
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Response<Void>> handleException(Exception e) {
 
-        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        GeneralErrorCode errorCode = GeneralErrorCode.INTERNAL_SERVER_ERROR;
         log.error("Unhandled Exception: ", e);
 
         return ResponseEntity.status(errorCode.getStatusCode()).body(Response.fail(errorCode));

--- a/src/main/java/ceos/diggindie/domain/keyword/service/KeywordService.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/service/KeywordService.java
@@ -1,6 +1,6 @@
 package ceos.diggindie.domain.keyword.service;
 
-import ceos.diggindie.common.code.ErrorCode;
+import ceos.diggindie.common.code.GeneralErrorCode;
 import ceos.diggindie.common.exception.GeneralException;
 import ceos.diggindie.domain.keyword.dto.KeywordRequest;
 import ceos.diggindie.domain.keyword.dto.KeywordResponse;
@@ -54,7 +54,7 @@ public class KeywordService {
                 .toList();
 
         if (!invalidIds.isEmpty()) {
-            throw new GeneralException(ErrorCode.BAD_REQUEST,
+            throw new GeneralException(GeneralErrorCode.BAD_REQUEST,
                     "유효하지 않은 키워드 ID: " + invalidIds);
         }
 


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #57

## 🪐 작업 내용
에러 핸들링 구조를 정리하였습니다.

### Exception 분리
- `BusinessException`: 도메인별 비즈니스 로직 예외 (세분화된 에러코드)
- `GeneralException`: 일반적인 시스템 예외

### ErrorCode 정리
- `BusinessErrorCode`: 도메인별 세분화된 에러코드 (MEMBER_NOT_FOUND, DUPLICATE_EMAIL 등)
- `GeneralErrorCode`: HTTP 표준 기반 일반 에러코드 (BAD_REQUEST, NOT_FOUND 등)

### GlobalExceptionHandler 개선
- `BusinessException`, `GeneralException` 핸들러 추가
- Validation, HTTP 요청 관련 예외 핸들러 추가
  - `HttpRequestMethodNotSupportedException` (405)
  - `HttpMediaTypeNotSupportedException` (415)
  - `MissingServletRequestParameterException` (400)
  - `HttpMessageNotReadableException` (400)

## ⚠️ PR 특이 사항
- response 정리하신 브랜치에서 하위 브랜치에 작업했습니다.

## 📚 Reference
- [REST API Error Handling Best Practices](https://www.baeldung.com/rest-api-error-handling-best-practices)

### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
