### PR TITLE
[FEAT] 밴드 검색 및 목록 반환 API

### DIFF
--- a/src/main/java/ceos/diggindie/common/entity/BaseEntity.java
+++ b/src/main/java/ceos/diggindie/common/entity/BaseEntity.java
@@ -3,12 +3,14 @@ package ceos.diggindie.common.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {

--- a/src/main/java/ceos/diggindie/common/enums/BandSortOrder.java
+++ b/src/main/java/ceos/diggindie/common/enums/BandSortOrder.java
@@ -1,0 +1,35 @@
+package ceos.diggindie.common.enums;
+
+import ceos.diggindie.common.code.GeneralErrorCode;
+import ceos.diggindie.common.exception.GeneralException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BandSortOrder {
+    recent("recent"),
+    alphabet("alphabet"),
+    scrap("scrap");
+
+    private final String value;
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static BandSortOrder from(String value) {
+        for (BandSortOrder order : BandSortOrder.values()) {
+            if (order.value.equalsIgnoreCase(value)) {
+                return order;
+            }
+        }
+        throw new GeneralException(GeneralErrorCode.BAD_REQUEST,
+                "지원하지 않는 정렬 타입입니다: " + value + ". (recent, alphabet, scrap 중 선택해주세요.)");
+    }
+}
+

--- a/src/main/java/ceos/diggindie/domain/band/controller/BandController.java
+++ b/src/main/java/ceos/diggindie/domain/band/controller/BandController.java
@@ -3,6 +3,7 @@ package ceos.diggindie.domain.band.controller;
 import ceos.diggindie.common.code.SuccessCode;
 import ceos.diggindie.common.response.Response;
 import ceos.diggindie.domain.band.dto.BandListResponse;
+import ceos.diggindie.domain.band.dto.BandSearchResponse;
 import ceos.diggindie.domain.band.service.BandService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -72,6 +73,33 @@ public class BandController {
                 SuccessCode.GET_SUCCESS,
                 bands,
                 "온보딩 밴드 검색 및 목록 반환 API"
+        );
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "아티스트 검색 및 목록 조회", description = "검색어, 정렬 조건, 페이징으로 아티스트 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/artists/search")
+    public ResponseEntity<Response<BandSearchResponse.ArtistListDTO>> searchArtists(
+            @Parameter(description = "정렬 기준 (recent: 최신순, alphabet: 가나다순, scrap: 스크랩순)", example = "recent")
+            @RequestParam(required = false, defaultValue = "recent") String order,
+            @Parameter(description = "검색어 (아티스트명, 키워드)", example = "쏜애플")
+            @RequestParam(required = false, defaultValue = "") String query,
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "20")
+            @RequestParam(required = false, defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        BandSearchResponse.ArtistListDTO result = bandService.searchArtists(query, order, pageable);
+
+        Response<BandSearchResponse.ArtistListDTO> response = Response.success(
+                SuccessCode.GET_SUCCESS,
+                result,
+                "아티스트 목록 조회 성공"
         );
 
         return ResponseEntity.ok().body(response);

--- a/src/main/java/ceos/diggindie/domain/band/controller/BandController.java
+++ b/src/main/java/ceos/diggindie/domain/band/controller/BandController.java
@@ -4,6 +4,7 @@ import ceos.diggindie.common.code.SuccessCode;
 import ceos.diggindie.common.response.Response;
 import ceos.diggindie.domain.band.dto.BandListResponse;
 import ceos.diggindie.domain.band.dto.BandSearchResponse;
+import ceos.diggindie.common.enums.BandSortOrder;
 import ceos.diggindie.domain.band.service.BandService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -85,7 +86,7 @@ public class BandController {
     @GetMapping("/artists/search")
     public ResponseEntity<Response<BandSearchResponse.ArtistListDTO>> searchArtists(
             @Parameter(description = "정렬 기준 (recent: 최신순, alphabet: 가나다순, scrap: 스크랩순)", example = "recent")
-            @RequestParam(required = false, defaultValue = "recent") String order,
+            @RequestParam(required = false, defaultValue = "recent") BandSortOrder order,
             @Parameter(description = "검색어 (아티스트명, 키워드)", example = "쏜애플")
             @RequestParam(required = false, defaultValue = "") String query,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")

--- a/src/main/java/ceos/diggindie/domain/band/controller/BandController.java
+++ b/src/main/java/ceos/diggindie/domain/band/controller/BandController.java
@@ -93,9 +93,9 @@ public class BandController {
             @Parameter(description = "페이지 크기", example = "20")
             @RequestParam(required = false, defaultValue = "20") int size
     ) {
+        
         Pageable pageable = PageRequest.of(page, size);
         BandSearchResponse.ArtistListDTO result = bandService.searchArtists(query, order, pageable);
-
         Response<BandSearchResponse.ArtistListDTO> response = Response.success(
                 SuccessCode.GET_SUCCESS,
                 result,

--- a/src/main/java/ceos/diggindie/domain/band/dto/BandSearchResponse.java
+++ b/src/main/java/ceos/diggindie/domain/band/dto/BandSearchResponse.java
@@ -13,31 +13,41 @@ public class BandSearchResponse {
 
     @Getter
     @Builder
+    public static class TopTrackInfo {
+        private String title;
+        private String externalUrl;
+
+        public static TopTrackInfo from(TopTrack topTrack) {
+            if (topTrack == null) {
+                return null;
+            }
+            return TopTrackInfo.builder()
+                    .title(topTrack.getTitle())
+                    .externalUrl(topTrack.getExternalUrl())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
     public static class ArtistInfo {
         private Long artistId;
         private String artistName;
         private List<String> keywords;
         private String artistImage;
-        private String topTrack;
+        private TopTrackInfo topTrack;
 
         public static ArtistInfo from(Band band) {
             List<String> keywordList = band.getBandKeywords().stream()
                     .map(bk -> bk.getKeyword().getKeyword())
                     .toList();
 
-            // TopTrack 테이블에서 title 가져오기
-            String topTrackTitle = null;
-            TopTrack topTrack = band.getTopTrack();
-            if (topTrack != null) {
-                topTrackTitle = topTrack.getTitle();
-            }
-
             return ArtistInfo.builder()
                     .artistId(band.getId())
                     .artistName(band.getBandName())
                     .keywords(keywordList)
                     .artistImage(band.getMainImage())
-                    .topTrack(topTrackTitle)
+                    .topTrack(TopTrackInfo.from(band.getTopTrack()))
                     .build();
         }
     }

--- a/src/main/java/ceos/diggindie/domain/band/dto/BandSearchResponse.java
+++ b/src/main/java/ceos/diggindie/domain/band/dto/BandSearchResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
+import java.util.Map;
 
 public class BandSearchResponse {
 
@@ -50,6 +51,23 @@ public class BandSearchResponse {
                     .topTrack(TopTrackInfo.from(band.getTopTrack()))
                     .build();
         }
+
+        // Native Query용 오버로드 메서드
+        public static ArtistInfo from(Band band, Map<Long, TopTrack> topTrackMap) {
+            List<String> keywordList = band.getBandKeywords().stream()
+                    .map(bk -> bk.getKeyword().getKeyword())
+                    .toList();
+
+            TopTrack topTrack = topTrackMap.get(band.getId());
+
+            return ArtistInfo.builder()
+                    .artistId(band.getId())
+                    .artistName(band.getBandName())
+                    .keywords(keywordList)
+                    .artistImage(band.getMainImage())
+                    .topTrack(TopTrackInfo.from(topTrack))
+                    .build();
+        }
     }
 
     @Getter
@@ -69,6 +87,26 @@ public class BandSearchResponse {
                     bandPage.hasNext(),
                     bandPage.getTotalElements(),
                     bandPage.getTotalPages()
+            );
+
+            return ArtistListDTO.builder()
+                    .artists(artistInfos)
+                    .pageInfo(pageInfo)
+                    .build();
+        }
+
+        // Native Query용 오버로드 메서드
+        public static ArtistListDTO from(List<Band> bands, Page<Long> idPage) {
+            List<ArtistInfo> artistInfos = bands.stream()
+                    .map(ArtistInfo::from)
+                    .toList();
+
+            PageInfo pageInfo = new PageInfo(
+                    idPage.getNumber(),
+                    idPage.getSize(),
+                    idPage.hasNext(),
+                    idPage.getTotalElements(),
+                    idPage.getTotalPages()
             );
 
             return ArtistListDTO.builder()

--- a/src/main/java/ceos/diggindie/domain/band/dto/BandSearchResponse.java
+++ b/src/main/java/ceos/diggindie/domain/band/dto/BandSearchResponse.java
@@ -1,0 +1,62 @@
+package ceos.diggindie.domain.band.dto;
+
+import ceos.diggindie.common.response.PageInfo;
+import ceos.diggindie.domain.band.entity.Band;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public class BandSearchResponse {
+
+    @Getter
+    @Builder
+    public static class ArtistInfo {
+        private Long artistId;
+        private String artistName;
+        private List<String> keywords;
+        private String artistImage;
+        private String topTrack;
+
+        public static ArtistInfo from(Band band) {
+            List<String> keywordList = band.getBandKeywords().stream()
+                    .map(bk -> bk.getKeyword().getKeyword())
+                    .toList();
+
+            return ArtistInfo.builder()
+                    .artistId(band.getId())
+                    .artistName(band.getBandName())
+                    .keywords(keywordList)
+                    .artistImage(band.getMainImage())
+                    .topTrack(band.getMainMusic())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class ArtistListDTO {
+        private List<ArtistInfo> artists;
+        private PageInfo pageInfo;
+
+        public static ArtistListDTO from(Page<Band> bandPage) {
+            List<ArtistInfo> artistInfos = bandPage.getContent().stream()
+                    .map(ArtistInfo::from)
+                    .toList();
+
+            PageInfo pageInfo = new PageInfo(
+                    bandPage.getNumber(),
+                    bandPage.getSize(),
+                    bandPage.hasNext(),
+                    bandPage.getTotalElements(),
+                    bandPage.getTotalPages()
+            );
+
+            return ArtistListDTO.builder()
+                    .artists(artistInfos)
+                    .pageInfo(pageInfo)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/band/entity/Band.java
+++ b/src/main/java/ceos/diggindie/domain/band/entity/Band.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,6 +55,7 @@ public class Band extends BaseEntity {
     @OneToMany(mappedBy = "band")
     private List<MemberBand> memberBands = new ArrayList<>();
 
+    @BatchSize(size = 100)
     @OneToMany(mappedBy = "band")
     private List<BandKeyword> bandKeywords = new ArrayList<>();
 

--- a/src/main/java/ceos/diggindie/domain/band/entity/TopTrack.java
+++ b/src/main/java/ceos/diggindie/domain/band/entity/TopTrack.java
@@ -5,11 +5,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Table(name = "top_track")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@BatchSize(size = 100)
 public class TopTrack {
 
     @Id

--- a/src/main/java/ceos/diggindie/domain/band/repository/BandRepository.java
+++ b/src/main/java/ceos/diggindie/domain/band/repository/BandRepository.java
@@ -54,7 +54,7 @@ public interface BandRepository extends JpaRepository<Band, Long> {
             "  b2.band_name ILIKE CONCAT('%', :query, '%') OR " +
             "  k.keyword ILIKE CONCAT('%', :query, '%')" +
             ") " +
-            "ORDER BY LOWER(b.band_name) COLLATE \"C\" ASC",
+            "ORDER BY LOWER(b.band_name) COLLATE \"ko_KR.utf8\" ASC",
             countQuery = "SELECT count(DISTINCT b.band_id) FROM band b " +
                     "LEFT JOIN band_keyword bk ON b.band_id = bk.band_id " +
                     "LEFT JOIN keyword k ON k.keyword_id = bk.keyword_id " +
@@ -78,7 +78,7 @@ public interface BandRepository extends JpaRepository<Band, Long> {
             "b.bandName ILIKE %:query% OR " +
             "k.keyword ILIKE %:query% " +
             "GROUP BY b.id, b.topTrack.id " +
-            "ORDER BY COUNT(bs) DESC, b.createdAt DESC",
+            "ORDER BY COUNT(DISTINCT bs.id) DESC, b.createdAt DESC",
             countQuery = "SELECT count(DISTINCT b) FROM Band b " +
                     "LEFT JOIN b.bandKeywords bk " +
                     "LEFT JOIN bk.keyword k " +

--- a/src/main/java/ceos/diggindie/domain/band/repository/BandRepository.java
+++ b/src/main/java/ceos/diggindie/domain/band/repository/BandRepository.java
@@ -16,7 +16,7 @@ public interface BandRepository extends JpaRepository<Band, Long> {
             "LEFT JOIN FETCH b.bandKeywords bk " +
             "LEFT JOIN FETCH bk.keyword k " +
             "WHERE :query IS NULL OR :query = '' OR " +
-            "b.bandName ILIKE %:query% OR " + // ILIKE + GIN
+            "b.bandName ILIKE %:query% OR " +
             "k.keyword ILIKE %:query%",
             countQuery = "SELECT count(DISTINCT b) FROM Band b " +
                     "LEFT JOIN b.bandKeywords bk " +
@@ -25,4 +25,57 @@ public interface BandRepository extends JpaRepository<Band, Long> {
                     "b.bandName ILIKE %:query% OR " +
                     "k.keyword ILIKE %:query%")
     Page<Band> searchBands(@Param("query") String query, Pageable pageable);
+
+    // 최신순 정렬
+    @Query(value = "SELECT DISTINCT b FROM Band b " +
+            "LEFT JOIN FETCH b.bandKeywords bk " +
+            "LEFT JOIN FETCH bk.keyword k " +
+            "WHERE :query IS NULL OR :query = '' OR " +
+            "b.bandName ILIKE %:query% OR " +
+            "k.keyword ILIKE %:query% " +
+            "ORDER BY b.createdAt DESC",
+            countQuery = "SELECT count(DISTINCT b) FROM Band b " +
+                    "LEFT JOIN b.bandKeywords bk " +
+                    "LEFT JOIN bk.keyword k " +
+                    "WHERE :query IS NULL OR :query = '' OR " +
+                    "b.bandName ILIKE %:query% OR " +
+                    "k.keyword ILIKE %:query%")
+    Page<Band> searchBandsByRecent(@Param("query") String query, Pageable pageable);
+
+    // 가나다순 정렬
+    @Query(value = "SELECT * FROM (" +
+            "SELECT DISTINCT b.* FROM band b " +
+            "LEFT JOIN band_keyword bk ON b.band_id = bk.band_id " +
+            "LEFT JOIN keyword k ON bk.keyword_id = k.keyword_id " +
+            "WHERE :query IS NULL OR :query = '' OR " +
+            "b.band_name ILIKE CONCAT('%', :query, '%') OR " +
+            "k.keyword ILIKE CONCAT('%', :query, '%')" +
+            ") AS distinct_bands " +
+            "ORDER BY band_name COLLATE \"ko_KR.utf8\" ASC",
+            countQuery = "SELECT count(DISTINCT b.band_id) FROM band b " +
+                    "LEFT JOIN band_keyword bk ON b.band_id = bk.band_id " +
+                    "LEFT JOIN keyword k ON bk.keyword_id = k.keyword_id " +
+                    "WHERE :query IS NULL OR :query = '' OR " +
+                    "b.band_name ILIKE CONCAT('%', :query, '%') OR " +
+                    "k.keyword ILIKE CONCAT('%', :query, '%')",
+            nativeQuery = true)
+    Page<Band> searchBandsByAlphabet(@Param("query") String query, Pageable pageable);
+
+    // 스크랩순 정렬
+    @Query(value = "SELECT DISTINCT b FROM Band b " +
+            "LEFT JOIN FETCH b.bandKeywords bk " +
+            "LEFT JOIN FETCH bk.keyword k " +
+            "LEFT JOIN b.bandScraps bs " +
+            "WHERE :query IS NULL OR :query = '' OR " +
+            "b.bandName ILIKE %:query% OR " +
+            "k.keyword ILIKE %:query% " +
+            "GROUP BY b.id " +
+            "ORDER BY COUNT(bs) DESC, b.bandName ASC",
+            countQuery = "SELECT count(DISTINCT b) FROM Band b " +
+                    "LEFT JOIN b.bandKeywords bk " +
+                    "LEFT JOIN bk.keyword k " +
+                    "WHERE :query IS NULL OR :query = '' OR " +
+                    "b.bandName ILIKE %:query% OR " +
+                    "k.keyword ILIKE %:query%")
+    Page<Band> searchBandsByScrap(@Param("query") String query, Pageable pageable);
 }

--- a/src/main/java/ceos/diggindie/domain/band/repository/BandRepository.java
+++ b/src/main/java/ceos/diggindie/domain/band/repository/BandRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BandRepository extends JpaRepository<Band, Long> {
@@ -44,7 +45,7 @@ public interface BandRepository extends JpaRepository<Band, Long> {
     Page<Band> searchBandsByRecent(@Param("query") String query, Pageable pageable);
 
     // 가나다순 정렬 
-    @Query(value = "SELECT b.* FROM band b " +
+    @Query(value = "SELECT b.band_id FROM band b " +
             "WHERE b.band_id IN (" +
             "  SELECT DISTINCT b2.band_id FROM band b2 " +
             "  LEFT JOIN band_keyword bk ON b2.band_id = bk.band_id " +
@@ -61,7 +62,11 @@ public interface BandRepository extends JpaRepository<Band, Long> {
                     "b.band_name ILIKE CONCAT('%', :query, '%') OR " +
                     "k.keyword ILIKE CONCAT('%', :query, '%')",
             nativeQuery = true)
-    Page<Band> searchBandsByAlphabet(@Param("query") String query, Pageable pageable);
+    Page<Long> searchBandIdsByAlphabet(@Param("query") String query, Pageable pageable);
+
+    // ID 목록으로 Band + TopTrack 함께 조회 (N+1 방지)
+    @Query("SELECT DISTINCT b FROM Band b LEFT JOIN FETCH b.topTrack WHERE b.id IN :ids")
+    List<Band> findByIdInWithTopTrack(@Param("ids") List<Long> ids);
 
     // 스크랩순 정렬 
     @Query(value = "SELECT b FROM Band b " +

--- a/src/main/java/ceos/diggindie/domain/band/repository/TopTrackRepository.java
+++ b/src/main/java/ceos/diggindie/domain/band/repository/TopTrackRepository.java
@@ -3,11 +3,17 @@ package ceos.diggindie.domain.band.repository;
 import ceos.diggindie.domain.band.entity.Band;
 import ceos.diggindie.domain.band.entity.TopTrack;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TopTrackRepository extends JpaRepository<TopTrack, Long> {
     Optional<TopTrack> findByBand(Band band);
     boolean existsByBand(Band band);
+
+    @Query("SELECT t FROM TopTrack t WHERE t.band.id IN :bandIds")
+    List<TopTrack> findByBandIdIn(@Param("bandIds") List<Long> bandIds);
 }
 

--- a/src/main/java/ceos/diggindie/domain/band/service/BandService.java
+++ b/src/main/java/ceos/diggindie/domain/band/service/BandService.java
@@ -7,6 +7,7 @@ import ceos.diggindie.domain.band.dto.BandSearchResponse;
 import ceos.diggindie.domain.band.entity.Artist;
 import ceos.diggindie.domain.band.entity.Band;
 import ceos.diggindie.domain.band.entity.BandsRawData;
+import ceos.diggindie.common.enums.BandSortOrder;
 import ceos.diggindie.domain.band.repository.ArtistRepository;
 import ceos.diggindie.domain.band.repository.BandRepository;
 import ceos.diggindie.domain.band.repository.BandsRawDataRepository;
@@ -237,9 +238,9 @@ public class BandService {
     }
 
     @Transactional(readOnly = true)
-    public BandSearchResponse.ArtistListDTO searchArtists(String query, String order, Pageable pageable) {
+    public BandSearchResponse.ArtistListDTO searchArtists(String query, BandSortOrder order, Pageable pageable) {
 
-        if ("alphabet".equals(order)) {
+        if (order == BandSortOrder.alphabet) {
             Page<Long> bandIdPage = bandRepository.searchBandIdsByAlphabet(query, pageable);
             List<Long> bandIds = bandIdPage.getContent();
 
@@ -257,10 +258,10 @@ public class BandService {
         }
 
         Page<Band> bandPage = switch (order) {
-            case "recent" -> bandRepository.searchBandsByRecent(query, pageable);
-            case "scrap" -> bandRepository.searchBandsByScrap(query, pageable);
+            case recent -> bandRepository.searchBandsByRecent(query, pageable);
+            case scrap -> bandRepository.searchBandsByScrap(query, pageable);
             default -> throw new GeneralException(GeneralErrorCode.BAD_REQUEST,
-                    "지원하지 않는 정렬 타입입니다: " + order + ". (recent, alphabet, scrap 중 선택해주세요.)");
+                    "지원하지 않는 정렬 타입입니다: " + order);
         };
 
         return BandSearchResponse.ArtistListDTO.from(bandPage);


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #63 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- 밴드 검색 및 목록 반환 API를 구현하였습니다.


## ⚠️ PR 특이 사항
- Band의 경우 TopTrack 테이블과는 1:1, BandKeyword와는 1:Many 관계를 구성합니다.
- 이때, N+1 문제 발생을 방지하기 위해 JPQL의 left join fetch를 활용합니다.

- 단, 한글 순서대로의 정렬을 위해서는 아래와 같은 Native Query 활용이 필요합니다. 
naive query 사용의 경우 JPA가 band와 topTrack, bandKeyWord 사이의 관계를 인식하지 못해 해당 인자들을 추후에 N+1번씩 조회하게 되는 문제가 발생합니다. 즉 N+1 문제가 지속됩니다.
이때, @BatchSize를 활용하여 개선하고자 했으나 oneToOne 관계에서 mappedBy쪽에 해당 어노테이션이 달리는 경우 @BarchSizer가 정상적으로 동작하지 않아 여전히 N+1 문제가 지속됩니다.
```java
// Band.java
@BatchSize(size = 100)
@OneToMany(mappedBy = "band")
private List<BandKeyword> bandKeywords = new ArrayList<>();
```

결국 가나다 순의 경우, 레포지토리 코드로 밴드 id 목록을 읽어온 후 서비스 레이어에서 TopTrack을 포함하여 밴드 id 목록의 밴드들 정보를 별도 쿼리로 조회하도록 수정하여 해당 문제를 해소했으나, 근본적인 해결책인지는 조금 더 고민이 필요합니다. 

관련하여서는 추가적인 공부가 필요할 듯 합니다.
```java
// BandRepository.java
@Query(value = "SELECT b.band_id FROM band b " +
        "WHERE b.band_id IN (" +
        "  SELECT DISTINCT b2.band_id FROM band b2 " +
        "  LEFT JOIN band_keyword bk ON b2.band_id = bk.band_id " +
        "  LEFT JOIN keyword k ON k.keyword_id = bk.keyword_id " +
        "  WHERE :query IS NULL OR :query = '' OR " +
        "  b2.band_name ILIKE CONCAT('%', :query, '%') OR " +
        "  k.keyword ILIKE CONCAT('%', :query, '%')" +
        ") " +
        "ORDER BY LOWER(b.band_name) COLLATE \"C\" ASC",
        countQuery = "SELECT count(DISTINCT b.band_id) FROM band b " +
                "LEFT JOIN band_keyword bk ON b.band_id = bk.band_id " +
                "LEFT JOIN keyword k ON k.keyword_id = bk.keyword_id " +
                "WHERE :query IS NULL OR :query = '' OR " +
                "b.band_name ILIKE CONCAT('%', :query, '%') OR " +
                "k.keyword ILIKE CONCAT('%', :query, '%')",
        nativeQuery = true)
Page<Long> searchBandIdsByAlphabet(@Param("query") String query, Pageable pageable);

// ID 목록으로 Band + TopTrack 함께 조회 (N+1 방지)
@Query("SELECT DISTINCT b FROM Band b LEFT JOIN FETCH b.topTrack WHERE b.id IN :ids")
List<Band> findByIdInWithTopTrack(@Param("ids") List<Long> ids);
```

```java
// BandService.java
@Transactional(readOnly = true)
public BandSearchResponse.ArtistListDTO searchArtists(String query, String order, Pageable pageable) {

    if ("alphabet".equals(order)) {
        Page<Long> bandIdPage = bandRepository.searchBandIdsByAlphabet(query, pageable);
        List<Long> bandIds = bandIdPage.getContent();

        // Band + TopTrack 한 번에 조회 (N+1 방지)
        List<Band> bands = bandRepository.findByIdInWithTopTrack(bandIds);

        // 정렬 순서 유지
        Map<Long, Band> bandMap = bands.stream()
                .collect(Collectors.toMap(Band::getId, Function.identity()));
        List<Band> orderedBands = bandIds.stream()
                .map(bandMap::get)
                .toList();

        return BandSearchResponse.ArtistListDTO.from(orderedBands, bandIdPage);
    }

    Page<Band> bandPage = switch (order) {
        case "recent" -> bandRepository.searchBandsByRecent(query, pageable);
        case "scrap" -> bandRepository.searchBandsByScrap(query, pageable);
        default -> throw new GeneralException(GeneralErrorCode.BAD_REQUEST,
                "지원하지 않는 정렬 타입입니다: " + order + ". (recent, alphabet, scrap 중 선택해주세요.)");
    };

    return BandSearchResponse.ArtistListDTO.from(bandPage);
}
```

## 📚 Reference




### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
