### PR TITLE
[FEAT] 이메일 인증 API 통합 (회원가입/비밀번호 재설정/아이디 찾기)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,6 +95,8 @@ jobs:
                   - OPENAI_MODEL=gpt-4o-mini
                   - SPOTIFY_CLIENT_ID=${{ secrets.SPOTIFY_CLIENT_ID }}
                   - SPOTIFY_CLIENT_SECRET=${{ secrets.SPOTIFY_CLIENT_SECRET }}
+                  - MAIL_USERNAME=${{ secrets.MAIL_USERNAME }}
+                  - MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }}
                 depends_on:
                   - redis
                 restart: unless-stopped

--- a/build.gradle
+++ b/build.gradle
@@ -56,10 +56,14 @@ dependencies {
 	runtimeOnly  'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
 	// reddison
-	implementation 'org.redisson:redisson:3.27.0'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
 
 	// swagger
 	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0"
+
+    // Mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/ceos/diggindie/common/code/BusinessErrorCode.java
+++ b/src/main/java/ceos/diggindie/common/code/BusinessErrorCode.java
@@ -8,14 +8,20 @@ import lombok.RequiredArgsConstructor;
 public enum BusinessErrorCode implements Code {
 
     // ==================== 회원 ====================
-    MEMBER_NOT_FOUND(404, "회원을 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND(404, "존재하지 않는 회원입니다."),
+    INVALID_CREDENTIALS(401, "아이디 또는 비밀번호가 올바르지 않습니다."),
     DUPLICATE_EMAIL(409, "이미 사용 중인 이메일입니다."),
+    DUPLICATE_USER_ID(409, "이미 사용 중인 아이디입니다."),
     DUPLICATE_NICKNAME(409, "이미 사용 중인 닉네임입니다."),
+
+    // ==================== 인증/토큰 ====================
+    REFRESH_TOKEN_NOT_FOUND(401, "Refresh token이 존재하지 않습니다."),
+    REFRESH_TOKEN_INVALID(401, "재로그인이 필요합니다."),
+    UNAUTHORIZED(401, "인증이 필요합니다."),
 
     // ==================== 이메일 인증 ====================
     EMAIL_SEND_FAILED(500, "이메일 발송에 실패했습니다."),
-    EMAIL_CODE_INVALID(400, "인증 코드가 올바르지 않습니다."),
-    EMAIL_CODE_EXPIRED(400, "인증 코드가 만료되었습니다."),
+    EMAIL_CODE_INVALID(400, "인증 코드가 올바르지 않거나 만료되었습니다."),
     EMAIL_NOT_REGISTERED(404, "등록되지 않은 이메일입니다."),
     EMAIL_ALREADY_EXISTS(409, "이미 존재하는 이메일입니다."),
     PASSWORD_TOO_SHORT(400, "비밀번호는 최소 8자 이상이어야 합니다."),

--- a/src/main/java/ceos/diggindie/common/code/BusinessErrorCode.java
+++ b/src/main/java/ceos/diggindie/common/code/BusinessErrorCode.java
@@ -12,6 +12,14 @@ public enum BusinessErrorCode implements Code {
     DUPLICATE_EMAIL(409, "이미 사용 중인 이메일입니다."),
     DUPLICATE_NICKNAME(409, "이미 사용 중인 닉네임입니다."),
 
+    // ==================== 이메일 인증 ====================
+    EMAIL_SEND_FAILED(500, "이메일 발송에 실패했습니다."),
+    EMAIL_CODE_INVALID(400, "인증 코드가 올바르지 않습니다."),
+    EMAIL_CODE_EXPIRED(400, "인증 코드가 만료되었습니다."),
+    EMAIL_NOT_REGISTERED(404, "등록되지 않은 이메일입니다."),
+    EMAIL_ALREADY_EXISTS(409, "이미 존재하는 이메일입니다."),
+    PASSWORD_TOO_SHORT(400, "비밀번호는 최소 8자 이상이어야 합니다."),
+
     // ==================== 아티스트 ====================
     ARTIST_NOT_FOUND(404, "아티스트를 찾을 수 없습니다."),
 

--- a/src/main/java/ceos/diggindie/common/code/BusinessErrorCode.java
+++ b/src/main/java/ceos/diggindie/common/code/BusinessErrorCode.java
@@ -13,6 +13,7 @@ public enum BusinessErrorCode implements Code {
     DUPLICATE_EMAIL(409, "이미 사용 중인 이메일입니다."),
     DUPLICATE_USER_ID(409, "이미 사용 중인 아이디입니다."),
     DUPLICATE_NICKNAME(409, "이미 사용 중인 닉네임입니다."),
+    EMAIL_VERIFICATION_BLOCKED(429, "인증 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요."),
 
     // ==================== 인증/토큰 ====================
     REFRESH_TOKEN_NOT_FOUND(401, "Refresh token이 존재하지 않습니다."),

--- a/src/main/java/ceos/diggindie/common/enums/EmailVerificationType.java
+++ b/src/main/java/ceos/diggindie/common/enums/EmailVerificationType.java
@@ -1,7 +1,32 @@
 package ceos.diggindie.common.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum EmailVerificationType {
-    SIGNUP,          // 회원가입
-    PASSWORD_RESET,  // 비밀번호 재설정
-    FIND_USER_ID     // 아이디 찾기
+    SIGNUP(
+            "회원가입 인증",
+            "아래 인증 코드를 입력하여 회원가입을 완료해주세요.",
+            "#007bff",
+            "[Diggindie] 회원가입 인증 코드"
+    ),
+    PASSWORD_RESET(
+            "비밀번호 재설정",
+            "아래 인증 코드를 입력하여 비밀번호를 재설정해주세요.",
+            "#dc3545",
+            "[Diggindie] 비밀번호 재설정 인증 코드"
+    ),
+    FIND_USER_ID(
+            "아이디 찾기",
+            "아래 인증 코드를 입력하여 아이디를 확인해주세요.",
+            "#28a745",
+            "[Diggindie] 아이디 찾기 인증 코드"
+    );
+
+    private final String title;
+    private final String description;
+    private final String color;
+    private final String subject;
 }

--- a/src/main/java/ceos/diggindie/common/enums/EmailVerificationType.java
+++ b/src/main/java/ceos/diggindie/common/enums/EmailVerificationType.java
@@ -1,0 +1,7 @@
+package ceos.diggindie.common.enums;
+
+public enum EmailVerificationType {
+    SIGNUP,          // 회원가입
+    PASSWORD_RESET,  // 비밀번호 재설정
+    FIND_USER_ID     // 아이디 찾기
+}

--- a/src/main/java/ceos/diggindie/domain/concert/controller/ConcertController.java
+++ b/src/main/java/ceos/diggindie/domain/concert/controller/ConcertController.java
@@ -61,11 +61,10 @@ public class ConcertController {
     @GetMapping("/concerts/recommendations")
     public ResponseEntity<Response<ConcertRecommendResponse>> getConcertRecommendations(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Response<ConcertRecommendResponse> response = Response.of(
+        Response<ConcertRecommendResponse> response = Response.success(
                 SuccessCode.GET_SUCCESS,
-                true,
-                "추천 공연 조회 API",
-                concertService.getRecommendation(userDetails.getMemberId())
+                concertService.getRecommendation(userDetails.getMemberId()),
+                "추천 공연 조회 API"
         );
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/ceos/diggindie/domain/member/controller/EmailController.java
+++ b/src/main/java/ceos/diggindie/domain/member/controller/EmailController.java
@@ -1,0 +1,61 @@
+package ceos.diggindie.domain.member.controller;
+
+import ceos.diggindie.common.code.SuccessCode;
+import ceos.diggindie.common.response.Response;
+import ceos.diggindie.domain.member.dto.email.EmailSendRequest;
+import ceos.diggindie.domain.member.dto.email.EmailVerifyRequest;
+import ceos.diggindie.domain.member.dto.email.EmailVerificationResponse;
+import ceos.diggindie.domain.member.service.AuthService;
+import ceos.diggindie.domain.member.service.EmailService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth/email")
+@Tag(name = "Email Verification", description = "이메일 인증 API")
+public class EmailController {
+
+    private final EmailService emailService;
+
+    @Operation(
+            summary = "인증 코드 발송",
+            description = "회원가입/비밀번호 재설정/아이디 찾기를 위한 인증 코드를 이메일로 발송합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증 코드 발송 성공"),
+            @ApiResponse(responseCode = "400", description = "등록되지 않은 이메일 (PASSWORD_RESET, FIND_USER_ID)"),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 이메일 (SIGNUP)")
+    })
+    @PostMapping("/send")
+    public ResponseEntity<Response<EmailVerificationResponse>> sendVerificationCode(
+            @Valid @RequestBody EmailSendRequest request
+    ) {
+        return ResponseEntity.ok(
+                Response.success(SuccessCode.INSERT_SUCCESS, emailService.sendVerificationCode(request))
+        );
+    }
+
+    @Operation(
+            summary = "인증 코드 확인",
+            description = "인증 코드를 확인합니다. PASSWORD_RESET은 newPassword 필수, FIND_USER_ID는 마스킹된 아이디 반환"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증 성공"),
+            @ApiResponse(responseCode = "400", description = "인증 코드 불일치 또는 만료")
+    })
+    @PostMapping("/verify")
+    public ResponseEntity<Response<EmailVerificationResponse>> verifyCode(
+            @Valid @RequestBody EmailVerifyRequest request
+    ) {
+        return ResponseEntity.ok(
+                Response.success(SuccessCode.INSERT_SUCCESS, emailService.verifyCode(request))
+        );
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/dto/email/EmailSendRequest.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/email/EmailSendRequest.java
@@ -1,0 +1,15 @@
+package ceos.diggindie.domain.member.dto.email;
+
+import ceos.diggindie.common.enums.EmailVerificationType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record EmailSendRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotNull(message = "인증 타입은 필수입니다.")
+        EmailVerificationType type
+) {}

--- a/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerificationResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerificationResponse.java
@@ -1,0 +1,11 @@
+package ceos.diggindie.domain.member.dto.email;
+
+public record EmailVerificationResponse(
+        String message,
+        boolean success,
+        String userId  // FIND_USER_ID일 때만 반환
+) {
+    public EmailVerificationResponse(String message, boolean success) {
+        this(message, success, null);
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerifyRequest.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerifyRequest.java
@@ -1,0 +1,22 @@
+package ceos.diggindie.domain.member.dto.email;
+
+import ceos.diggindie.common.enums.EmailVerificationType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record EmailVerifyRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "인증 코드는 필수입니다.")
+        String code,
+
+        @NotNull(message = "인증 타입은 필수입니다.")
+        EmailVerificationType type,
+
+        @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+        String newPassword  // PASSWORD_RESET일 때만 필수
+) {}

--- a/src/main/java/ceos/diggindie/domain/member/dto/oauth/RecentLoginPlatformResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/oauth/RecentLoginPlatformResponse.java
@@ -1,0 +1,22 @@
+package ceos.diggindie.domain.member.dto.oauth;
+
+import ceos.diggindie.common.enums.LoginPlatform;
+import ceos.diggindie.domain.member.entity.SocialAccount;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RecentLoginPlatformResponse {
+    private LoginPlatform platform;
+    private LocalDateTime lastLoginAt;
+
+    public static RecentLoginPlatformResponse from(SocialAccount socialAccount) {
+        return RecentLoginPlatformResponse.builder()
+                .platform(socialAccount.getPlatform())
+                .lastLoginAt(socialAccount.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/entity/Member.java
+++ b/src/main/java/ceos/diggindie/domain/member/entity/Member.java
@@ -100,4 +100,8 @@ public class Member extends BaseEntity {
         this.phone = phone;
     }
 
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
 }

--- a/src/main/java/ceos/diggindie/domain/member/repository/MemberRepository.java
+++ b/src/main/java/ceos/diggindie/domain/member/repository/MemberRepository.java
@@ -18,4 +18,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
 
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/ceos/diggindie/domain/member/service/AuthService.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/AuthService.java
@@ -1,7 +1,9 @@
 package ceos.diggindie.domain.member.service;
 
+import ceos.diggindie.common.code.BusinessErrorCode;
 import ceos.diggindie.common.config.security.jwt.JwtTokenProvider;
 import ceos.diggindie.common.enums.Role;
+import ceos.diggindie.common.exception.BusinessException;
 import ceos.diggindie.domain.member.dto.*;
 import ceos.diggindie.domain.member.entity.Member;
 import ceos.diggindie.domain.member.repository.MemberRepository;
@@ -35,14 +37,14 @@ public class AuthService {
     @Transactional(readOnly = true)
     public Member findMemberByUserId(String userId) {
         return memberRepository.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("아이디 또는 비밀번호가 올바르지 않습니다."));
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.INVALID_CREDENTIALS));
     }
 
     public LoginResponse login(LoginRequest request, HttpServletResponse response) {
         Member member = findMemberByUserId(request.userId());
 
         if (!passwordEncoder.matches(request.password(), member.getPassword())) {
-            throw new IllegalArgumentException("아이디 또는 비밀번호가 올바르지 않습니다.");
+            throw new BusinessException(BusinessErrorCode.INVALID_CREDENTIALS);
         }
 
         String accessToken = jwtTokenProvider.generateAccessToken(member.getExternalId(), member.getRole());
@@ -54,7 +56,7 @@ public class AuthService {
     @Transactional
     public Member createMember(SignupRequest request) {
         if (memberRepository.existsByEmail(request.email())) {
-            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+            throw new BusinessException(BusinessErrorCode.DUPLICATE_EMAIL);
         }
 
         String encodedPassword = passwordEncoder.encode(request.password());
@@ -124,7 +126,7 @@ public class AuthService {
         String refreshToken = extractRefreshTokenFromCookie(request);
 
         if (refreshToken == null) {
-            throw new IllegalArgumentException("Refresh token이 존재하지 않습니다.");
+            throw new BusinessException(BusinessErrorCode.REFRESH_TOKEN_NOT_FOUND);
         }
 
         String externalId = jwtTokenProvider.parseClaims(refreshToken).getSubject();
@@ -132,11 +134,11 @@ public class AuthService {
         if (!refreshTokenService.validate(externalId, refreshToken)) {
             refreshTokenService.delete(externalId);
             removeRefreshTokenCookie(response);
-            throw new IllegalArgumentException("재로그인이 필요합니다.");
+            throw new BusinessException(BusinessErrorCode.REFRESH_TOKEN_INVALID);
         }
 
         Member member = memberRepository.findByExternalId(externalId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.MEMBER_NOT_FOUND));
 
         String newAccessToken = jwtTokenProvider.generateAccessToken(externalId, member.getRole());
         setRefreshToken(response, externalId, member.getRole());

--- a/src/main/java/ceos/diggindie/domain/member/service/EmailService.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/EmailService.java
@@ -1,0 +1,195 @@
+package ceos.diggindie.domain.member.service;
+
+import ceos.diggindie.common.code.BusinessErrorCode;
+import ceos.diggindie.common.enums.EmailVerificationType;
+import ceos.diggindie.common.exception.BusinessException;
+import ceos.diggindie.domain.member.dto.email.EmailSendRequest;
+import ceos.diggindie.domain.member.dto.email.EmailVerifyRequest;
+import ceos.diggindie.domain.member.dto.email.EmailVerificationResponse;
+import ceos.diggindie.domain.member.entity.Member;
+import ceos.diggindie.domain.member.repository.MemberRepository;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final RedissonClient redissonClient;
+    private final JavaMailSender mailSender;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    private static final String CODE_PREFIX = "email_verify:";
+    private static final long CODE_VALIDITY_MINUTES = 5;
+
+    public EmailVerificationResponse sendVerificationCode(EmailSendRequest request) {
+        switch (request.type()) {
+            case SIGNUP -> {
+                if (memberRepository.existsByEmail(request.email())) {
+                    throw new BusinessException(BusinessErrorCode.EMAIL_ALREADY_EXISTS);
+                }
+            }
+            case PASSWORD_RESET, FIND_USER_ID -> {
+                if (!memberRepository.existsByEmail(request.email())) {
+                    throw new BusinessException(BusinessErrorCode.EMAIL_NOT_REGISTERED);
+                }
+            }
+        }
+
+        String code = generateCode();
+        saveCode(request.email(), code, request.type());
+        sendVerificationEmail(request.email(), code, request.type());
+
+        return new EmailVerificationResponse("인증 코드가 발송되었습니다.", true);
+    }
+
+    @Transactional
+    public EmailVerificationResponse verifyCode(EmailVerifyRequest request) {
+        boolean isValid = verifyCode(request.email(), request.code(), request.type());
+
+        if (!isValid) {
+            throw new BusinessException(BusinessErrorCode.EMAIL_CODE_INVALID);
+        }
+
+        return switch (request.type()) {
+            case SIGNUP -> new EmailVerificationResponse("이메일 인증이 완료되었습니다.", true);
+
+            case PASSWORD_RESET -> {
+                validateNewPassword(request.newPassword());
+                Member member = findMemberByEmail(request.email());
+                member.updatePassword(passwordEncoder.encode(request.newPassword()));
+                yield new EmailVerificationResponse("비밀번호가 변경되었습니다.", true);
+            }
+
+            case FIND_USER_ID -> {
+                Member member = findMemberByEmail(request.email());
+                String maskedUserId = maskUserId(member.getUserId());
+                yield new EmailVerificationResponse("아이디 찾기가 완료되었습니다.", true, maskedUserId);
+            }
+        };
+    }
+
+    private void validateNewPassword(String newPassword) {
+        if (newPassword == null || newPassword.isBlank()) {
+            throw new BusinessException(BusinessErrorCode.PASSWORD_TOO_SHORT);
+        }
+        if (newPassword.length() < 8) {
+            throw new BusinessException(BusinessErrorCode.PASSWORD_TOO_SHORT);
+        }
+    }
+
+    private Member findMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.EMAIL_NOT_REGISTERED));
+    }
+
+    private String maskUserId(String userId) {
+        if (userId.length() <= 3) {
+            return userId.charAt(0) + "**";
+        }
+        return userId.substring(0, 3) + "*".repeat(userId.length() - 3);
+    }
+
+    public String generateCode() {
+        SecureRandom random = new SecureRandom();
+        int code = 100000 + random.nextInt(900000);
+        return String.valueOf(code);
+    }
+
+    public void saveCode(String email, String code, EmailVerificationType type) {
+        String key = buildKey(email, type);
+        RBucket<String> bucket = redissonClient.getBucket(key);
+        bucket.set(code, CODE_VALIDITY_MINUTES, TimeUnit.MINUTES);
+    }
+
+    public boolean verifyCode(String email, String code, EmailVerificationType type) {
+        String key = buildKey(email, type);
+        RBucket<String> bucket = redissonClient.getBucket(key);
+        String storedCode = bucket.get();
+
+        if (storedCode != null && storedCode.equals(code)) {
+            bucket.delete();
+            return true;
+        }
+        return false;
+    }
+
+    private String buildKey(String email, EmailVerificationType type) {
+        return CODE_PREFIX + type.name().toLowerCase() + ":" + email;
+    }
+
+    public void sendVerificationEmail(String to, String code, EmailVerificationType type) {
+        String subject = buildSubject(type);
+        String content = buildContent(code, type);
+        sendEmail(to, subject, content);
+    }
+
+    private void sendEmail(String to, String subject, String content) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setText(content, true);
+
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            throw new BusinessException(BusinessErrorCode.EMAIL_SEND_FAILED);
+        }
+    }
+
+    private String buildSubject(EmailVerificationType type) {
+        return switch (type) {
+            case SIGNUP -> "[Diggindie] 회원가입 인증 코드";
+            case PASSWORD_RESET -> "[Diggindie] 비밀번호 재설정 인증 코드";
+            case FIND_USER_ID -> "[Diggindie] 아이디 찾기 인증 코드";
+        };
+    }
+
+    private String buildContent(String code, EmailVerificationType type) {
+        String title = switch (type) {
+            case SIGNUP -> "회원가입 인증";
+            case PASSWORD_RESET -> "비밀번호 재설정";
+            case FIND_USER_ID -> "아이디 찾기";
+        };
+
+        String description = switch (type) {
+            case SIGNUP -> "아래 인증 코드를 입력하여 회원가입을 완료해주세요.";
+            case PASSWORD_RESET -> "아래 인증 코드를 입력하여 비밀번호를 재설정해주세요.";
+            case FIND_USER_ID -> "아래 인증 코드를 입력하여 아이디를 확인해주세요.";
+        };
+
+        String color = switch (type) {
+            case SIGNUP -> "#007bff";
+            case PASSWORD_RESET -> "#dc3545";
+            case FIND_USER_ID -> "#28a745";
+        };
+
+        return """
+            <html>
+            <body style="font-family: Arial, sans-serif; padding: 20px;">
+                <h2 style="color: #333;">Diggindie %s</h2>
+                <p>%s</p>
+                <div style="background-color: #f5f5f5; padding: 20px; text-align: center; margin: 20px 0;">
+                    <span style="font-size: 32px; font-weight: bold; letter-spacing: 5px; color: %s;">%s</span>
+                </div>
+                <p style="color: #666;">이 코드는 5분간 유효합니다.</p>
+                <p style="color: #999; font-size: 12px;">본인이 요청하지 않은 경우 이 이메일을 무시해주세요.</p>
+            </body>
+            </html>
+            """.formatted(title, description, color, code);
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/service/EmailService.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/EmailService.java
@@ -152,44 +152,22 @@ public class EmailService {
     }
 
     private String buildSubject(EmailVerificationType type) {
-        return switch (type) {
-            case SIGNUP -> "[Diggindie] 회원가입 인증 코드";
-            case PASSWORD_RESET -> "[Diggindie] 비밀번호 재설정 인증 코드";
-            case FIND_USER_ID -> "[Diggindie] 아이디 찾기 인증 코드";
-        };
+        return type.getSubject();
     }
 
     private String buildContent(String code, EmailVerificationType type) {
-        String title = switch (type) {
-            case SIGNUP -> "회원가입 인증";
-            case PASSWORD_RESET -> "비밀번호 재설정";
-            case FIND_USER_ID -> "아이디 찾기";
-        };
-
-        String description = switch (type) {
-            case SIGNUP -> "아래 인증 코드를 입력하여 회원가입을 완료해주세요.";
-            case PASSWORD_RESET -> "아래 인증 코드를 입력하여 비밀번호를 재설정해주세요.";
-            case FIND_USER_ID -> "아래 인증 코드를 입력하여 아이디를 확인해주세요.";
-        };
-
-        String color = switch (type) {
-            case SIGNUP -> "#007bff";
-            case PASSWORD_RESET -> "#dc3545";
-            case FIND_USER_ID -> "#28a745";
-        };
-
         return """
-            <html>
-            <body style="font-family: Arial, sans-serif; padding: 20px;">
-                <h2 style="color: #333;">Diggindie %s</h2>
-                <p>%s</p>
-                <div style="background-color: #f5f5f5; padding: 20px; text-align: center; margin: 20px 0;">
-                    <span style="font-size: 32px; font-weight: bold; letter-spacing: 5px; color: %s;">%s</span>
-                </div>
-                <p style="color: #666;">이 코드는 5분간 유효합니다.</p>
-                <p style="color: #999; font-size: 12px;">본인이 요청하지 않은 경우 이 이메일을 무시해주세요.</p>
-            </body>
-            </html>
-            """.formatted(title, description, color, code);
+        <html>
+        <body style="font-family: Arial, sans-serif; padding: 20px;">
+            <h2 style="color: #333;">Diggindie %s</h2>
+            <p>%s</p>
+            <div style="background-color: #f5f5f5; padding: 20px; text-align: center; margin: 20px 0;">
+                <span style="font-size: 32px; font-weight: bold; letter-spacing: 5px; color: %s;">%s</span>
+            </div>
+            <p style="color: #666;">이 코드는 5분간 유효합니다.</p>
+            <p style="color: #999; font-size: 12px;">본인이 요청하지 않은 경우 이 이메일을 무시해주세요.</p>
+        </body>
+        </html>
+        """.formatted(type.getTitle(), type.getDescription(), type.getColor(), code);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,18 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## 🛰️ Issue Number
close #30

## 🪐 작업 내용
### 이메일 인증 API 통합
- 기존 5개 API → 2개로 통합했습니다.
  - `POST /api/auth/email/send` - 인증 코드 발송
  - `POST /api/auth/email/verify` - 인증 코드 확인
- `EmailVerificationType` enum으로 목적 구분 (SIGNUP, PASSWORD_RESET, FIND_USER_ID)

### 주요 변경 사항
- `EmailService`: 코드 생성/저장/검증 + 이메일 발송 통합
- `EmailController`: 이메일 인증 전용 컨트롤러 분리
- `BusinessErrorCode`: 이메일 관련 에러 코드 추가
- `Member`: `updatePassword()` 메서드 추가
- `MemberRepository`: `findByEmail()` 메서드 추가

- `AuthService`: 에러 핸들링 `BusinessException` 으로 전부 바꿔두었습니다.

## ⚠️ PR 특이 사항
- Redis(Redisson) 사용하여 인증 코드 저장 (5분 TTL)
- Gmail SMTP 사용 시 앱 비밀번호 필요한데, 노션환경변수에 적어두었으니 참고 부탁드립니다.
- 환경변수 추가 필요: `MAIL_USERNAME`, `MAIL_PASSWORD`

## 📚 Reference

### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?