### PR TITLE
[FIX] 아티스트 상세 조회 관련 오류 해결 및 밴드 키워드 부여

### DIFF
--- a/src/main/java/ceos/diggindie/domain/band/controller/BandScrapController.java
+++ b/src/main/java/ceos/diggindie/domain/band/controller/BandScrapController.java
@@ -36,7 +36,7 @@ public class BandScrapController {
             @ApiResponse(responseCode = "204", description = "스크랩 처리 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
-    @PostMapping("/my/artists")
+    @PatchMapping("/my/artists")
     public ResponseEntity<Response<Void>> toggleBandScraps(
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/ceos/diggindie/domain/band/repository/ArtistRepository.java
+++ b/src/main/java/ceos/diggindie/domain/band/repository/ArtistRepository.java
@@ -3,6 +3,9 @@ package ceos.diggindie.domain.band.repository;
 import ceos.diggindie.domain.band.entity.Artist;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ArtistRepository extends JpaRepository<Artist, Long> {
+    List<Artist> findByBandId(Long bandId);
 }
 

--- a/src/main/java/ceos/diggindie/domain/band/repository/BandRepository.java
+++ b/src/main/java/ceos/diggindie/domain/band/repository/BandRepository.java
@@ -89,12 +89,15 @@ public interface BandRepository extends JpaRepository<Band, Long> {
                     "k.keyword ILIKE %:query%")
     Page<Band> searchBandsByScrap(@Param("query") String query, Pageable pageable);
 
-    // 아티스트 상세 조회 (연관된 모든 정보 Fetch Join)
     @Query("SELECT DISTINCT b FROM Band b " +
             "LEFT JOIN FETCH b.bandKeywords bk " +
             "LEFT JOIN FETCH bk.keyword " +
-            "LEFT JOIN FETCH b.artists " +
             "LEFT JOIN FETCH b.topTrack " +
             "WHERE b.id = :bandId")
-    Optional<Band> findByIdWithDetails(@Param("bandId") Long bandId);
+    Optional<Band> findByIdWithKeywordsAndTopTrack(@Param("bandId") Long bandId);
+
+    @Query("SELECT DISTINCT b FROM Band b " +
+            "LEFT JOIN FETCH b.artists " +
+            "WHERE b.id = :bandId")
+    Optional<Band> findByIdWithArtists(@Param("bandId") Long bandId);
 }

--- a/src/main/java/ceos/diggindie/domain/band/service/BandService.java
+++ b/src/main/java/ceos/diggindie/domain/band/service/BandService.java
@@ -53,7 +53,6 @@ public class BandService {
     private final OpenAIService openAIService;
     private final SpotifyService spotifyService;
     private final ObjectMapper objectMapper;
-    private final TopTrackRepository topTrackRepository;
     private final ConcertRepository concertRepository;
     private final BandScrapRepository bandScrapRepository;
     private final AlbumRepository albumRepository;
@@ -288,14 +287,16 @@ public class BandService {
 
         LocalDateTime now = LocalDateTime.now();
 
-        Band band = bandRepository.findByIdWithDetails(bandId)
+        Band band = bandRepository.findByIdWithKeywordsAndTopTrack(bandId)
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.ARTIST_NOT_FOUND));
+
+        List<Artist> artists = artistRepository.findByBandId(bandId);
 
         List<String> keywords = band.getBandKeywords().stream()
                 .map(bk -> bk.getKeyword().getKeyword())
                 .toList();
 
-        List<String> members = band.getArtists().stream()
+        List<String> members = artists.stream()
                 .map(Artist::getArtistName)
                 .toList();
 

--- a/src/main/java/ceos/diggindie/domain/keyword/controller/KeywordController.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/controller/KeywordController.java
@@ -90,4 +90,18 @@ public class KeywordController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "밴드 키워드 자동 할당(관리자용)", description = "GPT를 사용해 모든 밴드에 키워드 2개씩 자동 할당합니다.")
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/api/admin/bands/assign-keywords")
+    public ResponseEntity<Response<Void>> assignKeywordsToBands() {
+        keywordService.assignKeywordsToBands();
+
+        Response<Void> response = Response.success(
+                SuccessCode.UPDATE_SUCCESS,
+                "밴드 키워드 할당 완료"
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/ceos/diggindie/domain/keyword/entity/BandKeyword.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/entity/BandKeyword.java
@@ -4,6 +4,7 @@ import ceos.diggindie.common.entity.BaseEntity;
 import ceos.diggindie.domain.band.entity.Band;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,5 +26,11 @@ public class BandKeyword extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "keyword_id", nullable = false)
     private Keyword keyword;
+
+    @Builder
+    public BandKeyword(Band band, Keyword keyword) {
+        this.band = band;
+        this.keyword = keyword;
+    }
 
 }

--- a/src/main/java/ceos/diggindie/domain/keyword/repository/BandKeywordRepository.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/repository/BandKeywordRepository.java
@@ -1,0 +1,11 @@
+package ceos.diggindie.domain.keyword.repository;
+
+import ceos.diggindie.domain.keyword.entity.BandKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BandKeywordRepository extends JpaRepository<BandKeyword, Long> {
+
+    boolean existsByBandId(Long bandId);
+
+    void deleteAllByBandId(Long bandId);
+}

--- a/src/main/java/ceos/diggindie/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/repository/KeywordRepository.java
@@ -3,5 +3,12 @@ package ceos.diggindie.domain.keyword.repository;
 import ceos.diggindie.domain.keyword.entity.Keyword;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+
+    Optional<Keyword> findByKeyword(String keyword);
+
+    List<Keyword> findAllByKeywordIn(List<String> keywords);
 }

--- a/src/main/java/ceos/diggindie/domain/keyword/service/KeywordService.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/service/KeywordService.java
@@ -2,28 +2,67 @@ package ceos.diggindie.domain.keyword.service;
 
 import ceos.diggindie.common.code.GeneralErrorCode;
 import ceos.diggindie.common.exception.GeneralException;
+import ceos.diggindie.domain.band.entity.Band;
+import ceos.diggindie.domain.band.repository.BandRepository;
 import ceos.diggindie.domain.keyword.dto.KeywordRequest;
 import ceos.diggindie.domain.keyword.dto.KeywordResponse;
+import ceos.diggindie.domain.keyword.entity.BandKeyword;
 import ceos.diggindie.domain.keyword.entity.Keyword;
 import ceos.diggindie.domain.keyword.entity.MemberKeyword;
+import ceos.diggindie.domain.keyword.repository.BandKeywordRepository;
 import ceos.diggindie.domain.keyword.repository.KeywordRepository;
 import ceos.diggindie.domain.keyword.repository.MemberKeywordRepository;
 import ceos.diggindie.domain.member.entity.Member;
 import ceos.diggindie.domain.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
+import ceos.diggindie.domain.openai.dto.PromptRequest;
+import ceos.diggindie.domain.openai.service.OpenAIService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+// import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+@Slf4j
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class KeywordService {
 
     private final KeywordRepository keywordRepository;
     private final MemberKeywordRepository memberKeywordRepository;
     private final MemberRepository memberRepository;
+    private final BandRepository bandRepository;
+    private final BandKeywordRepository bandKeywordRepository;
+    private final OpenAIService openAIService;
+    private final ObjectMapper objectMapper;
+    private final KeywordService self;
+
+    public KeywordService(
+            KeywordRepository keywordRepository,
+            MemberKeywordRepository memberKeywordRepository,
+            MemberRepository memberRepository,
+            BandRepository bandRepository,
+            BandKeywordRepository bandKeywordRepository,
+            OpenAIService openAIService,
+            ObjectMapper objectMapper,
+            @Lazy KeywordService self
+    ) {
+        this.keywordRepository = keywordRepository;
+        this.memberKeywordRepository = memberKeywordRepository;
+        this.memberRepository = memberRepository;
+        this.bandRepository = bandRepository;
+        this.bandKeywordRepository = bandKeywordRepository;
+        this.openAIService = openAIService;
+        this.objectMapper = objectMapper;
+        this.self = self;
+    }
 
     public List<KeywordResponse> getAllKeywords() {
         return keywordRepository.findAll().stream()
@@ -63,5 +102,103 @@ public class KeywordService {
                 .toList();
 
         memberKeywordRepository.saveAll(memberKeywords);
+    }
+
+    public void assignKeywordsToBands() {
+        List<Band> bands = bandRepository.findAll();
+        List<Keyword> allKeywords = keywordRepository.findAll();
+
+        String keywordList = allKeywords.stream()
+                .map(Keyword::getKeyword)
+                .collect(Collectors.joining(", "));
+
+        Map<String, Keyword> keywordMap = allKeywords.stream()
+                .collect(Collectors.toMap(Keyword::getKeyword, Function.identity()));
+
+        int total = bands.size();
+        int completed = 0, failed = 0, skipped = 0;
+
+        log.info("========== 키워드 할당 시작 (총 {}개 밴드) ==========", total);
+
+        for (Band band : bands) {
+            try {
+                if (bandKeywordRepository.existsByBandId(band.getId())) {
+                    skipped++;
+                    log.info("[{}/{}] {} - 스킵 (이미 존재)", skipped + completed + failed, total, band.getBandName());
+                    continue;
+                }
+
+                List<String> selectedKeywords = fetchKeywordsFromAI(band, keywordList);
+
+                if (!selectedKeywords.isEmpty()) {
+                    self.saveBandKeywords(band.getId(), selectedKeywords, keywordMap);
+                    completed++;
+                    log.info("[{}/{}] {} - 성공: {}", skipped + completed + failed, total, band.getBandName(), selectedKeywords);
+                } else {
+                    failed++;
+                    log.warn("[{}/{}] {} - 실패 (키워드 추출 실패)", skipped + completed + failed, total, band.getBandName());
+                }
+            } catch (Exception e) {
+                failed++;
+                log.error("[{}/{}] {} - 오류: {}", skipped + completed + failed, total, band.getBandName(), e.getMessage());
+            }
+        }
+
+        log.info("========== 완료: 성공 {}, 실패 {}, 스킵 {} ==========", completed, failed, skipped);
+    }
+
+    private List<String> fetchKeywordsFromAI(Band band, String keywordList) {
+        String prompt = """
+            다음 아티스트 정보를 보고, 아래 키워드 목록에서 가장 어울리는 키워드 2개를 선택해줘.
+            
+            [아티스트 정보]
+            - 이름: %s
+            - 설명: %s
+            - 대표곡: %s
+            
+            [키워드 목록]
+            %s
+            
+            반드시 JSON 배열 형식으로만 응답해. 다른 텍스트 없이.
+            예시: ["서정적", "잔잔한"]
+            """.formatted(
+                band.getBandName(),
+                band.getDescription() != null ? band.getDescription() : "정보 없음",
+                band.getMainMusic() != null ? band.getMainMusic() : "정보 없음",
+                keywordList
+        );
+
+        String response = openAIService.callOpenAI(new PromptRequest(prompt));
+
+        try {
+            return objectMapper.readValue(extractJsonArray(response), new TypeReference<List<String>>() {});
+        } catch (Exception e) {
+            log.warn("[{}] JSON 파싱 실패: {}", band.getBandName(), e.getMessage());
+            return List.of();
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveBandKeywords(Long bandId, List<String> keywordNames, Map<String, Keyword> keywordMap) {
+        Band band = bandRepository.getReferenceById(bandId);
+
+        for (String name : keywordNames) {
+            Keyword keyword = keywordMap.get(name.trim());
+            if (keyword != null) {
+                bandKeywordRepository.save(BandKeyword.builder()
+                        .band(band)
+                        .keyword(keyword)
+                        .build());
+            }
+        }
+    }
+
+    private String extractJsonArray(String response) {
+        int start = response.indexOf('[');
+        int end = response.lastIndexOf(']');
+        if (start != -1 && end != -1 && end > start) {
+            return response.substring(start, end + 1);
+        }
+        return response;
     }
 }


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #79


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->

1. 아티스트 상세 조회 API MultipleBagFetchException 해결

- Band 엔티티에서 bandKeywords와 artists 두 개의 List를 동시에 fetch join할 때 발생하는 Hibernate 오류 수정
- 쿼리 분리: findByIdWithKeywordsAndTopTrack(), findByIdWithArtists() 로 분리
- ArtistRepository.findByBandId() 추가하여 artists 직접 조회

2. 밴드 키워드 자동 부여 API (관리자용)

- GPT(gpt-4o-mini)를 활용해 밴드 정보 기반으로 키워드 2개 자동 할당
→ 해당 기능을 배포 후 돌리는 경우에는 깃헙 시크릿 환경변수 수정해야합니다.
- POST /api/admin/bands/assign-keywords
- KeywordAssignService 분리하여 트랜잭션 정상 동작 보장
- 밴드별 개별 트랜잭션 처리 (하나 실패해도 나머지 저장)
- 이미 키워드가 있는 밴드는 스킵


## ⚠️ PR 특이 사항




## 📚 Reference




### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
