### PR TITLE
[FEAT] 월별 공연 정보 일괄 등록 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 
 	// swagger
 	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0"
+
+    // OpenCSV
+    implementation 'com.opencsv:opencsv:5.9'
 }
 
 tasks.named('test') {

--- a/src/main/java/ceos/diggindie/domain/band/entity/Band.java
+++ b/src/main/java/ceos/diggindie/domain/band/entity/Band.java
@@ -25,7 +25,7 @@ public class Band extends BaseEntity {
     @Column(name = "band_id")
     private Long id;
 
-    @Column(name = "band_name", length = 20)
+    @Column(name = "band_name", length = 100)
     private String bandName;
 
     @Column(name = "main_image", length = 200)

--- a/src/main/java/ceos/diggindie/domain/concert/controller/ConcertImportController.java
+++ b/src/main/java/ceos/diggindie/domain/concert/controller/ConcertImportController.java
@@ -1,0 +1,38 @@
+package ceos.diggindie.domain.concert.controller;
+
+import ceos.diggindie.domain.concert.dto.CsvImportResult;
+import ceos.diggindie.domain.concert.service.ConcertCsvImportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Concert Import", description = "공연 데이터 가져오기 (관리자)")
+public class ConcertImportController {
+
+    private final ConcertCsvImportService importService;
+
+    @Operation(summary = "CSV 파일로 공연 일괄 등록 (관리자)")
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping(value = "/api/admin/concerts/import/csv", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<CsvImportResult> importFromCsv(
+            @RequestPart("file") MultipartFile file
+    ) {
+        log.info("CSV Import 요청: {}", file.getOriginalFilename());
+
+        if (file.isEmpty()) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        CsvImportResult result = importService.importFromCsv(file);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/concert/dto/ConcertCsvRow.java
+++ b/src/main/java/ceos/diggindie/domain/concert/dto/ConcertCsvRow.java
@@ -1,0 +1,55 @@
+package ceos.diggindie.domain.concert.dto;
+
+import com.opencsv.bean.CsvBindByName;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ConcertCsvRow {
+
+    @CsvBindByName(column = "id")
+    private Long externalId;
+
+    @CsvBindByName(column = "documentId")
+    private String documentId;
+
+    @CsvBindByName(column = "title")
+    private String title;
+
+    @CsvBindByName(column = "slug")
+    private String slug;
+
+    @CsvBindByName(column = "startDate")
+    private String startDate;
+
+    @CsvBindByName(column = "endDate")
+    private String endDate;
+
+    @CsvBindByName(column = "description")
+    private String description;
+
+    @CsvBindByName(column = "preorderPrice")
+    private String preorderPrice;
+
+    @CsvBindByName(column = "onsitePrice")
+    private String onsitePrice;
+
+    @CsvBindByName(column = "performers")
+    private String performers;
+
+    @CsvBindByName(column = "venue")
+    private String venue;
+
+    @CsvBindByName(column = "address")
+    private String address;
+
+    @CsvBindByName(column = "ticketLink")
+    private String ticketLink;
+
+    @CsvBindByName(column = "posterUrl")
+    private String posterUrl;
+
+    @CsvBindByName(column = "url")
+    private String url;
+}

--- a/src/main/java/ceos/diggindie/domain/concert/dto/CsvImportResult.java
+++ b/src/main/java/ceos/diggindie/domain/concert/dto/CsvImportResult.java
@@ -1,0 +1,15 @@
+package ceos.diggindie.domain.concert.dto;
+
+import java.util.List;
+
+public record CsvImportResult(
+        int totalRows,
+        int successCount,
+        int skippedCount,
+        int failedCount,
+        List<String> errors
+) {
+    public static CsvImportResult of(int total, int success, int skipped, List<String> errors) {
+        return new CsvImportResult(total, success, skipped, errors.size(), errors);
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/concert/entity/BandConcert.java
+++ b/src/main/java/ceos/diggindie/domain/concert/entity/BandConcert.java
@@ -26,4 +26,10 @@ public class BandConcert extends BaseEntity {
     @JoinColumn(name = "concert_id", nullable = false)
     private Concert concert;
 
+    public static BandConcert of(Band band, Concert concert) {
+        BandConcert bandConcert = new BandConcert();
+        bandConcert.band = band;
+        bandConcert.concert = concert;
+        return bandConcert;
+    }
 }

--- a/src/main/java/ceos/diggindie/domain/concert/entity/Concert.java
+++ b/src/main/java/ceos/diggindie/domain/concert/entity/Concert.java
@@ -3,6 +3,7 @@ package ceos.diggindie.domain.concert.entity;
 import ceos.diggindie.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
@@ -20,7 +21,7 @@ public class Concert extends BaseEntity {
     @Column(name = "concert_id")
     private Long id;
 
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false, length = 200)  // 30 → 200 (제목 길이 늘림)
     private String title;
 
     @Column(name = "start_date", nullable = false)
@@ -41,10 +42,10 @@ public class Concert extends BaseEntity {
     @Column(name = "main_img", length = 1000)
     private String mainImg;
 
-    @Column(name = "main_url", length = 200)
+    @Column(name = "main_url", length = 500)
     private String mainUrl;
 
-    @Column(name = "book_url", length = 200)
+    @Column(name = "book_url", length = 500)
     private String bookUrl;
 
     @Column(nullable = false, columnDefinition = "INT DEFAULT 0")
@@ -59,6 +60,28 @@ public class Concert extends BaseEntity {
 
     @OneToMany(mappedBy = "concert")
     private List<ConcertScrap> concertScraps = new ArrayList<>();
+
+    @Builder
+    private Concert(String title, LocalDateTime startDate, LocalDateTime endDate,
+                    String description, Integer preorderPrice, Integer onSitePrice,
+                    String mainImg, String mainUrl, String bookUrl, ConcertHall concertHall) {
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.description = description;
+        this.preorderPrice = preorderPrice;
+        this.onSitePrice = onSitePrice;
+        this.mainImg = mainImg;
+        this.mainUrl = mainUrl;
+        this.bookUrl = bookUrl;
+        this.concertHall = concertHall;
+        this.views = 0;
+    }
+
+    public void updatePrices(Integer preorderPrice, Integer onSitePrice) {
+        this.preorderPrice = preorderPrice;
+        this.onSitePrice = onSitePrice;
+    }
 
     public void increaseViews() {
         this.views++;

--- a/src/main/java/ceos/diggindie/domain/concert/entity/ConcertHall.java
+++ b/src/main/java/ceos/diggindie/domain/concert/entity/ConcertHall.java
@@ -38,4 +38,10 @@ public class ConcertHall extends BaseEntity {
     @OneToMany(mappedBy = "concertHall")
     private List<Concert> concerts = new ArrayList<>();
 
+    public static ConcertHall create(String name, String address) {
+        ConcertHall hall = new ConcertHall();
+        hall.name = name;
+        hall.address = address;
+        return hall;
+    }
 }

--- a/src/main/java/ceos/diggindie/domain/concert/repository/BandConcertRepository.java
+++ b/src/main/java/ceos/diggindie/domain/concert/repository/BandConcertRepository.java
@@ -1,6 +1,8 @@
 package ceos.diggindie.domain.concert.repository;
 
+import ceos.diggindie.domain.band.entity.Band;
 import ceos.diggindie.domain.concert.entity.BandConcert;
+import ceos.diggindie.domain.concert.entity.Concert;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,4 +26,6 @@ public interface BandConcertRepository extends JpaRepository<BandConcert, Long> 
     List<Object[]> findConcertIdsByBandIdsOrderByBandCount(
             @Param("bandIds") List<Long> bandIds,
             @Param("now") LocalDateTime now);
+
+    boolean existsByBandAndConcert(Band band, Concert concert);
 }

--- a/src/main/java/ceos/diggindie/domain/concert/repository/ConcertHallRepository.java
+++ b/src/main/java/ceos/diggindie/domain/concert/repository/ConcertHallRepository.java
@@ -1,0 +1,10 @@
+package ceos.diggindie.domain.concert.repository;
+
+import ceos.diggindie.domain.concert.entity.ConcertHall;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ConcertHallRepository extends JpaRepository<ConcertHall, Long> {
+    Optional<ConcertHall> findByName(String name);
+}

--- a/src/main/java/ceos/diggindie/domain/concert/repository/ConcertRepository.java
+++ b/src/main/java/ceos/diggindie/domain/concert/repository/ConcertRepository.java
@@ -136,4 +136,6 @@ public interface ConcertRepository extends JpaRepository<Concert, Long> {
             WHERE c.id IN :ids
             """)
     List<Concert> findAllByIdWithBandConcerts(@Param("ids") List<Long> ids);
+
+    boolean existsByTitleAndStartDate(String title, LocalDateTime startDate);
 }

--- a/src/main/java/ceos/diggindie/domain/concert/service/ConcertAppender.java
+++ b/src/main/java/ceos/diggindie/domain/concert/service/ConcertAppender.java
@@ -1,0 +1,148 @@
+package ceos.diggindie.domain.concert.service;
+
+import ceos.diggindie.domain.band.entity.Band;
+import ceos.diggindie.domain.band.repository.BandRepository;
+import ceos.diggindie.domain.concert.dto.ConcertCsvRow;
+import ceos.diggindie.domain.concert.entity.BandConcert;
+import ceos.diggindie.domain.concert.entity.Concert;
+import ceos.diggindie.domain.concert.entity.ConcertHall;
+import ceos.diggindie.domain.concert.repository.BandConcertRepository;
+import ceos.diggindie.domain.concert.repository.ConcertHallRepository;
+import ceos.diggindie.domain.concert.repository.ConcertRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ConcertAppender {
+
+    private final ConcertRepository concertRepository;
+    private final ConcertHallRepository hallRepository;
+    private final BandRepository bandRepository;
+    private final BandConcertRepository bandConcertRepository;
+
+    private static final String IMAGE_DOMAIN = "https://cdn.indistreet.app";
+
+    /**
+     * CSV 한 줄을 기반으로 공연 정보를 저장한다.
+     * 실패 시 해당 Row는 롤백된다.
+     */
+    @Transactional
+    public boolean appendConcert(ConcertCsvRow row) {
+        // 필수값 검증
+        if (row.getTitle() == null || row.getTitle().isBlank()) return false;
+
+        LocalDateTime startDate = parseDateTime(row.getStartDate());
+        if (startDate == null) return false;
+
+        // 중복 공연 스킵
+        if (concertRepository.existsByTitleAndStartDate(row.getTitle(), startDate)) {
+            log.debug("중복 스킵: {}", row.getTitle());
+            return false;
+        }
+
+        // 공연장 조회 또는 생성
+        ConcertHall hall = findOrCreateHall(row.getVenue(), row.getAddress());
+
+        // 공연 저장
+        Concert concert = Concert.builder()
+                .title(truncate(row.getTitle(), 200))
+                .description(row.getDescription())
+                .startDate(startDate)
+                .endDate(parseDateTime(row.getEndDate()))
+                .mainImg(fixUrl(row.getPosterUrl()))
+                .mainUrl(row.getUrl())
+                .bookUrl(row.getTicketLink())
+                .preorderPrice(parsePrice(row.getPreorderPrice()))
+                .onSitePrice(parsePrice(row.getOnsitePrice()))
+                .concertHall(hall)
+                .build();
+
+        concertRepository.save(concert);
+
+        // 출연진 저장 및 매핑
+        savePerformers(row.getPerformers(), concert);
+
+        log.info("저장 완료: {}", row.getTitle());
+        return true;
+    }
+
+    private ConcertHall findOrCreateHall(String name, String address) {
+        if (name == null || name.isBlank()) name = "미정";
+
+        String finalName = truncate(name, 100);
+        String finalAddress = address != null ? truncate(address, 300) : "";
+
+        return hallRepository.findByName(finalName)
+                .orElseGet(() -> hallRepository.save(
+                        ConcertHall.create(finalName, finalAddress)
+                ));
+    }
+
+    private void savePerformers(String performersStr, Concert concert) {
+        if (performersStr == null || performersStr.isBlank()) return;
+
+        String[] names = performersStr.split("[,/]\\s*");
+
+        for (String rawName : names) {
+            final String name = rawName.trim();
+            if (name.isEmpty()) continue;
+
+            Band band = bandRepository.findByBandName(name)
+                    .orElseGet(() -> bandRepository.save(
+                            Band.builder()
+                                    .bandName(name)
+                                    .description(name)
+                                    .build()
+                    ));
+
+            if (!bandConcertRepository.existsByBandAndConcert(band, concert)) {
+                bandConcertRepository.save(BandConcert.of(band, concert));
+            }
+        }
+    }
+
+    // ---------- util ----------
+
+    private LocalDateTime parseDateTime(String dateStr) {
+        if (dateStr == null || dateStr.isBlank()) return null;
+        try {
+            return dateStr.contains("T")
+                    ? OffsetDateTime.parse(dateStr).toLocalDateTime()
+                    : LocalDateTime.parse(dateStr);
+        } catch (Exception e) {
+            log.warn("날짜 파싱 실패: {}", dateStr);
+            return null;
+        }
+    }
+
+    private Integer parsePrice(String priceStr) {
+        if (priceStr == null || priceStr.isBlank()) return null;
+        try {
+            String cleanStr = priceStr.replaceAll("[^0-9.]", "");
+            if (cleanStr.isEmpty()) return null;
+            return (int) Double.parseDouble(cleanStr);
+        } catch (Exception e) {
+            log.warn("가격 파싱 실패: {}", priceStr);
+            return null;
+        }
+    }
+
+    private String truncate(String str, int maxLength) {
+        if (str == null) return null;
+        return str.length() > maxLength ? str.substring(0, maxLength) : str;
+    }
+
+    private String fixUrl(String url) {
+        if (url == null || url.isBlank()) return null;
+        if (url.startsWith("http")) return url;
+        if (url.startsWith("/")) return IMAGE_DOMAIN + url;
+        return url;
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/concert/service/ConcertCsvImportService.java
+++ b/src/main/java/ceos/diggindie/domain/concert/service/ConcertCsvImportService.java
@@ -1,0 +1,70 @@
+package ceos.diggindie.domain.concert.service;
+
+import ceos.diggindie.domain.concert.dto.ConcertCsvRow;
+import ceos.diggindie.domain.concert.dto.CsvImportResult;
+import com.opencsv.bean.CsvToBeanBuilder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ConcertCsvImportService {
+
+    private final ConcertAppender concertAppender;
+
+    public CsvImportResult importFromCsv(MultipartFile file) {
+        List<ConcertCsvRow> rows = parseCsv(file);
+
+        int success = 0;
+        int skipped = 0;
+        List<String> errors = new ArrayList<>();
+
+        for (int i = 0; i < rows.size(); i++) {
+            ConcertCsvRow row = rows.get(i);
+            try {
+                boolean saved = concertAppender.appendConcert(row);
+
+                if (saved) success++;
+                else skipped++;
+
+            } catch (Exception e) {
+                String error = String.format(
+                        "Row %d (%s): %s",
+                        i + 2, row.getTitle(), e.getMessage()
+                );
+                errors.add(error);
+                log.error("CSV Import Error [Row {}]", i + 2, e);
+            }
+        }
+
+        log.info("CSV Import 완료 - 총: {}, 성공: {}, 스킵: {}, 실패: {}",
+                rows.size(), success, skipped, errors.size());
+
+        return CsvImportResult.of(rows.size(), success, skipped, errors);
+    }
+
+    private List<ConcertCsvRow> parseCsv(MultipartFile file) {
+        try (Reader reader =
+                     new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8)) {
+
+            return new CsvToBeanBuilder<ConcertCsvRow>(reader)
+                    .withType(ConcertCsvRow.class)
+                    .withIgnoreLeadingWhiteSpace(true)
+                    .withIgnoreEmptyLine(true)
+                    .build()
+                    .parse();
+
+        } catch (Exception e) {
+            throw new RuntimeException("CSV 파싱 실패", e);
+        }
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number

close #91

## 🪐 작업 내용

### 1. 크롤링 및 데이터 수집 방식 선정

* 기존 Java 환경에서의 크롤링은 현재 스펙상 메모리 부족 및 라이브러리 호환성 이슈로 인해 불가능하여, Python(Google Colab)을 활용한 별도 크롤링 방식을 차선책으로 택했습니다.
* Colab에서 수집된 CSV 파일을 추가 가공 없이 API에 업로드하면, 서버에서 자동으로 파싱하여 DB에 적재하도록 구현했습니다.
* 크롤링 Colab 링크
  [https://colab.research.google.com/drive/1aOIAAmBYkuJ0ighsaA06dCt5a2HPpBm6?usp=sharing](https://colab.research.google.com/drive/1aOIAAmBYkuJ0ighsaA06dCt5a2HPpBm6?usp=sharing)

### 2. CSV Import API 구현 (/api/admin/concerts/import/csv)

* OpenCSV 라이브러리를 사용하여 CSV 파일을 객체로 매핑합니다.
* 트랜잭션 분리: 전체 데이터 중 일부 행(Row)에서 에러가 발생해도 나머지 데이터는 정상 저장되도록 처리했습니다.

  * 이를 위해 @Transactional의 Self-Invocation(자기 호출) 문제를 해결하고자 저장 로직을 ConcertAppender 클래스로 분리했습니다.
* 권한 제어: 관리자(ADMIN) 권한이 있는 사용자만 접근 가능하도록 @PreAuthorize를 적용했습니다.

### 3. 데이터 파싱 및 정제 로직 강화

* 가격 데이터: 소수점(40000.0)이나 콤마(40,000)가 포함된 문자열을 정수형(40000)으로 안전하게 변환하는 로직을 추가했습니다.
* 이미지 URL: 상대 경로(/uploads/...)로 들어오는 데이터에 도메인을 붙여 절대 경로로 변환하여 저장합니다. 해당 경우 S3 사용하지 않고 크롤링한 곳에서 바로 사진 가져오도록 했습니다.
* 데이터 무결성: 밴드 이름 구분자 처리 및 중복 생성을 방지하는 로직을 적용했습니다.

## ⚠️ PR 특이 사항


* 크롤링 된 밴드명 중 길이가 긴 데이터(20자 이상)가 존재하여 Band 엔티티의 band_name 컬럼 길이를 100자로 늘렸습니다.


```sql
-- PostgreSQL 예시
ALTER TABLE band ALTER COLUMN band_name TYPE VARCHAR(100);
```


## 📚 Reference

크롤링 Colab 코드
[https://colab.research.google.com/drive/1aOIAAmBYkuJ0ighsaA06dCt5a2HPpBm6?usp=sharing](https://colab.research.google.com/drive/1aOIAAmBYkuJ0ighsaA06dCt5a2HPpBm6?usp=sharing)

## ✅ Check List

[x] 코드가 정상적으로 컴파일되나요?
[x] 포스트맨에서 결과값을 제대로 확인했나요?
[x] 리뷰어 설정을 지정했나요?
[x] merge할 브랜치의 위치를 확인했나요?
[x] Label을 지정했나요?

