### PR TITLE
[FIX] 콘서트 검색 및 목록 반환 구조 변경

### DIFF
--- a/src/main/java/ceos/diggindie/domain/concert/controller/ConcertController.java
+++ b/src/main/java/ceos/diggindie/domain/concert/controller/ConcertController.java
@@ -20,7 +20,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;

--- a/src/main/java/ceos/diggindie/domain/concert/dto/ConcertRecommendResponse.java
+++ b/src/main/java/ceos/diggindie/domain/concert/dto/ConcertRecommendResponse.java
@@ -29,7 +29,7 @@ public record ConcertRecommendResponse(
                         concert.getId(),
                         concert.getTitle(),
                         formatDuration(concert),
-                        ConcertDDayCalculator.calculateWithPastDays(concert.getStartDate()),
+                        ConcertDDayCalculator.calculate(concert.getStartDate()),
                         concert.getMainImg(),
                         concert.getBandConcerts().stream()
                                 .map(bc -> new LineUp(

--- a/src/main/java/ceos/diggindie/domain/concert/dto/ConcertsListResponse.java
+++ b/src/main/java/ceos/diggindie/domain/concert/dto/ConcertsListResponse.java
@@ -30,7 +30,7 @@ public record ConcertsListResponse(
                     .map(bc -> bc.getBand().getBandName())
                     .toList();
 
-            // D-Day 계산
+            // D-Day 계산 (과거 공연은 '공연 종료'로 표시)
             String dDay = ConcertDDayCalculator.calculate(concert.getStartDate());
 
             // 기간 포맷팅


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #92 

## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- 콘서트 검색 및 목록 반환 API의 구조를 변경하였습니다.
- 1차적으로 조건에 부합하는(검색, 정렬 순서) 콘서트의 id 목록을 찾아내고, 이 목록을 활용하여 2차적으로 반환할 concert 정보를 읽어오도록 구현하였습니다.


## ⚠️ PR 특이 사항
- 단일 쿼리를 이용하여 검색 + 정렬 + 목록 반환을 한번에 시도하였으나 JPQL과 PostgreSql간 문법 차이로 인하여, 많은 오류가 있었으나 명확한 해결법을 찾지 못했습니다. 
- 이에 2번의 쿼리를 활용하여 기능적으로는 문제가 없도록 구현하였으나, DB에 접근이 2차례로 늘어난 관계로 API의 응답 속도가 현저히 떨어졌습니다. 구조적으로 개선할 방안을 쿼리 분석을 거쳐 찾아내야 할 것 같습니다.



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
