### PR TITLE
[FEAT] 마케팅 동의 API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,20 @@
 services:
-  backend:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: diggindie-be
-    ports:
-      - "8080:8080"
-    depends_on:
-      - redis
-    env_file:
-      - .env
-    environment:
-      TZ: Asia/Seoul
-      REDIS_HOST: redis
-      REDIS_PORT: 6379
-    restart: unless-stopped
+#  backend:
+#    build:
+#      context: .
+#      dockerfile: Dockerfile
+#    container_name: diggindie-be
+#    ports:
+#      - "8080:8080"
+#    depends_on:
+#      - redis
+#    env_file:
+#      - .env
+#    environment:
+#      TZ: Asia/Seoul
+#      REDIS_HOST: redis
+#      REDIS_PORT: 6379
+#    restart: unless-stopped
 
   redis:
     image: redis:7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,20 @@
 services:
-#  backend:
-#    build:
-#      context: .
-#      dockerfile: Dockerfile
-#    container_name: diggindie-be
-#    ports:
-#      - "8080:8080"
-#    depends_on:
-#      - redis
-#    env_file:
-#      - .env
-#    environment:
-#      TZ: Asia/Seoul
-#      REDIS_HOST: redis
-#      REDIS_PORT: 6379
-#    restart: unless-stopped
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: diggindie-be
+    ports:
+      - "8080:8080"
+    depends_on:
+      - redis
+    env_file:
+      - .env
+    environment:
+      TZ: Asia/Seoul
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+    restart: unless-stopped
 
   redis:
     image: redis:7

--- a/src/main/java/ceos/diggindie/domain/member/controller/AuthController.java
+++ b/src/main/java/ceos/diggindie/domain/member/controller/AuthController.java
@@ -7,6 +7,7 @@ import ceos.diggindie.common.response.Response;
 import ceos.diggindie.domain.member.dto.*;
 import ceos.diggindie.domain.member.dto.oauth.*;
 import ceos.diggindie.domain.member.service.AuthService;
+import ceos.diggindie.domain.member.service.MemberService;
 import ceos.diggindie.domain.member.service.OAuth2Service;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -29,6 +30,7 @@ public class AuthController {
 
     private final AuthService authService;
     private final OAuth2Service oAuth2Service;
+    private final MemberService memberService;
 
     @Operation(summary = "회원가입", description = "새로운 회원을 등록합니다.")
     @ApiResponses({
@@ -246,4 +248,46 @@ public class AuthController {
         return ResponseEntity.ok().body(response);
     }
 
+    @Operation(summary = "마케팅 동의 변경", description = "로그인한 사용자의 마케팅 동의를 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "마케팅 동의 변경 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @PreAuthorize("isAuthenticated()")
+    @PatchMapping("/my/marketing-consent")
+    public ResponseEntity<Response<MarketingConsentResponse>> updateMarketingConsent(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody MarketingConsentRequest request
+    ) {
+        Response<MarketingConsentResponse> response = Response.success(
+                SuccessCode.UPDATE_SUCCESS,
+                memberService.updateMarketingConsent(userDetails.getExternalId(), request),
+                "마케팅 동의 변경 API"
+        );
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "마케팅 동의 조회", description = "로그인한 사용자의 마케팅 동의 여부를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/my/marketing-consent")
+    public ResponseEntity<Response<MarketingConsentResponse>> getMarketingConsent(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Response<MarketingConsentResponse> response = Response.success(
+                SuccessCode.GET_SUCCESS,
+                memberService.getMarketingConsent(userDetails.getExternalId()),
+                "마케팅 동의 조회 API"
+        );
+
+        return ResponseEntity.ok().body(response);
+    }
+
+
+
 }
+

--- a/src/main/java/ceos/diggindie/domain/member/dto/MarketingConsentRequest.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/MarketingConsentRequest.java
@@ -1,0 +1,13 @@
+package ceos.diggindie.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "마케팅 동의 변경 요청")
+public record MarketingConsentRequest(
+        @Schema(description = "마케팅 동의 여부", example = "true")
+        @NotNull(message = "마케팅 동의 여부는 필수입니다.")
+        Boolean marketingConsent
+) {
+}
+

--- a/src/main/java/ceos/diggindie/domain/member/dto/MarketingConsentResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/MarketingConsentResponse.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "마케팅 동의 응답")
 public record MarketingConsentResponse(
         @Schema(description = "마케팅 동의 여부", example = "true")
-        boolean marketingConsent
+        Boolean marketingConsent
 ) {
 }
 

--- a/src/main/java/ceos/diggindie/domain/member/dto/MarketingConsentResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/MarketingConsentResponse.java
@@ -1,0 +1,11 @@
+package ceos.diggindie.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "마케팅 동의 응답")
+public record MarketingConsentResponse(
+        @Schema(description = "마케팅 동의 여부", example = "true")
+        boolean marketingConsent
+) {
+}
+

--- a/src/main/java/ceos/diggindie/domain/member/entity/Member.java
+++ b/src/main/java/ceos/diggindie/domain/member/entity/Member.java
@@ -57,6 +57,9 @@ public class Member extends BaseEntity {
     @Column(name = "profile_img", length = 150)
     private String profileImg;
 
+    @Column(name = "marketing_consent")
+    private Boolean marketingConsent;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SocialAccount> socialAccounts = new ArrayList<>();
 
@@ -98,6 +101,7 @@ public class Member extends BaseEntity {
         this.email = email;
         this.role = Role.ROLE_USER;
         this.phone = phone;
+        this.marketingConsent = false;
     }
 
     public void updatePassword(String password) {
@@ -112,6 +116,10 @@ public class Member extends BaseEntity {
         this.recentLoginPlatform = platform;
     }
 
+    public void updateMarketingConsent(Boolean marketingConsent) {
+        this.marketingConsent = marketingConsent;
+    }
+
     // 소셜 로그인 전용
     public static Member createSocialMember(String email, LoginPlatform platform) {
         Member member = new Member();
@@ -120,6 +128,7 @@ public class Member extends BaseEntity {
         member.email = email;
         member.role = Role.ROLE_USER;
         member.recentLoginPlatform = platform;
+        member.marketingConsent = false;
         return member;
     }
 

--- a/src/main/java/ceos/diggindie/domain/member/service/MemberService.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/MemberService.java
@@ -1,9 +1,9 @@
 package ceos.diggindie.domain.member.service;
 
 import ceos.diggindie.common.code.BusinessErrorCode;
-import ceos.diggindie.common.code.GeneralErrorCode;
 import ceos.diggindie.common.exception.BusinessException;
-import ceos.diggindie.common.exception.GeneralException;
+import ceos.diggindie.domain.member.dto.MarketingConsentRequest;
+import ceos.diggindie.domain.member.dto.MarketingConsentResponse;
 import ceos.diggindie.domain.member.entity.Member;
 import ceos.diggindie.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +33,24 @@ public class MemberService {
         return memberRepository.findByUserId(userId)
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.MEMBER_NOT_FOUND,
                         "회원을 찾을 수 없습니다."));
+    }
+
+
+    @Transactional
+    public MarketingConsentResponse updateMarketingConsent(String externalId, MarketingConsentRequest request) {
+        Member member = memberRepository.findByExternalId(externalId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.MEMBER_NOT_FOUND,
+                        "회원을 찾을 수 없습니다."));
+        member.updateMarketingConsent(request.marketingConsent());
+        return new MarketingConsentResponse(member.getMarketingConsent());
+    }
+
+    @Transactional(readOnly = true)
+    public MarketingConsentResponse getMarketingConsent(String externalId) {
+        Member member = memberRepository.findByExternalId(externalId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.MEMBER_NOT_FOUND,
+                        "회원을 찾을 수 없습니다."));
+        return new MarketingConsentResponse(member.getMarketingConsent());
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: ${DDL_AUTO:update}
+      ddl-auto: ${DDL_AUTO:validate}
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #103 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- 마케팅 동의 내역을 기록하기 위한 column을 member table에 추가하였습니다.
- 마케팅 동의 저장 및 반환 API를 구현하였습니다.


## ⚠️ PR 특이 사항
- 에러 방지를 위해 기존 유저의 모든 마케팅 동의를 true로 세팅해두었습니다.
- 추가적인 DB 테이블 구조 업데이트는 불필요할 것으로 판단하여, application.yaml과 .env의 ddl-auto를 validate로 설정하였습니다.



## 📚 Reference




### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
