### PR TITLE
[REFACTOR] OAuth2 Callback 관련 API 통합

### DIFF
--- a/src/main/java/ceos/diggindie/common/enums/LoginPlatform.java
+++ b/src/main/java/ceos/diggindie/common/enums/LoginPlatform.java
@@ -3,6 +3,9 @@ package ceos.diggindie.common.enums;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+import java.util.Optional;
+
 @Getter
 @RequiredArgsConstructor
 public enum LoginPlatform {
@@ -13,4 +16,14 @@ public enum LoginPlatform {
     LOCAL("로컬");
 
     private final String description;
+
+    public static Optional<LoginPlatform> fromName(String name) {
+        if (name == null || name.isBlank()) {
+            return Optional.empty();
+        }
+
+        return Arrays.stream(values())
+                .filter(p -> p.name().equalsIgnoreCase(name))
+                .findFirst();
+    }
 }

--- a/src/main/java/ceos/diggindie/domain/member/controller/AuthController.java
+++ b/src/main/java/ceos/diggindie/domain/member/controller/AuthController.java
@@ -217,11 +217,12 @@ public class AuthController {
     @Operation(summary = "OAuth2 인증 URL 조회", description = "소셜 로그인을 위한 인증 URL을 반환합니다.")
     @GetMapping("/auth/oauth2/url/{platform}")
     public ResponseEntity<Response<OAuth2UrlResponse>> getOAuth2AuthUrl(
-            @PathVariable LoginPlatform platform
+            @PathVariable LoginPlatform platform,
+            @RequestParam(defaultValue = "login") String purpose
     ) {
         Response<OAuth2UrlResponse> response = Response.success(
                 SuccessCode.GET_SUCCESS,
-                oAuth2Service.getAuthUrl(platform),
+                oAuth2Service.getAuthUrl(platform, purpose),
                 "OAuth2 인증 URL 조회 API"
         );
         return ResponseEntity.ok().body(response);

--- a/src/main/java/ceos/diggindie/domain/member/controller/AuthController.java
+++ b/src/main/java/ceos/diggindie/domain/member/controller/AuthController.java
@@ -155,22 +155,17 @@ public class AuthController {
         return ResponseEntity.ok().body(response);
     }
 
-    @Operation(summary = "소셜 계정 연동", description = "기존 계정에 소셜 계정을 연동합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "연동 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-            @ApiResponse(responseCode = "409", description = "이미 연동된 계정")
-    })
-    @PreAuthorize("isAuthenticated()")
-    @PostMapping("/auth/oauth2/link")
-    public ResponseEntity<Response<OAuth2LinkResponse>> linkSocialAccount(
+    @PostMapping("/auth/oauth2/callback")
+    @Operation(summary = "OAuth2 통합 콜백", description = "로그인/연동을 state 기반으로 자동 분기 처리")
+    public ResponseEntity<Response<OAuth2CallbackResponse>> handleCallback(
+            @RequestBody OAuth2CallbackRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Valid @RequestBody OAuth2LinkRequest request
-    ) {
-        Response<OAuth2LinkResponse> response = Response.success(
-                SuccessCode.INSERT_SUCCESS,
-                oAuth2Service.linkSocialAccount(userDetails, request),
-                "소셜 계정 연동 API"
+            HttpServletResponse httpResponse) {
+
+        Response<OAuth2CallbackResponse> response = Response.success(
+                SuccessCode.GET_SUCCESS,
+                oAuth2Service.handleCallback(request, userDetails, httpResponse),
+                "OAuth2 통합 콜백 API"
         );
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/ceos/diggindie/domain/member/dto/oauth/OAuth2CallbackRequest.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/oauth/OAuth2CallbackRequest.java
@@ -1,0 +1,11 @@
+package ceos.diggindie.domain.member.dto.oauth;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OAuth2CallbackRequest {
+    private String code;
+    private String state;
+}

--- a/src/main/java/ceos/diggindie/domain/member/dto/oauth/OAuth2CallbackResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/oauth/OAuth2CallbackResponse.java
@@ -1,0 +1,68 @@
+package ceos.diggindie.domain.member.dto.oauth;
+
+import ceos.diggindie.common.enums.LoginPlatform;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OAuth2CallbackResponse {
+
+    private String type;  // "login" 또는 "link"
+    private LoginData loginData;
+    private LinkData linkData;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LoginData {
+        private boolean newMember;
+        private String externalId;
+        private String userId;
+        private String email;
+        private LoginPlatform platform;
+        private String accessToken;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LinkData {
+        private boolean success;
+        private LoginPlatform platform;
+        private String email;
+        private String message;
+    }
+
+    public static OAuth2CallbackResponse login(OAuth2LoginResponse result) {
+        return OAuth2CallbackResponse.builder()
+                .type("login")
+                .loginData(LoginData.builder()
+                        .newMember(result.isNewMember())
+                        .externalId(result.getExternalId())
+                        .userId(result.getUserId())
+                        .email(result.getEmail())
+                        .platform(result.getPlatform())
+                        .accessToken(result.getAccessToken())
+                        .build())
+                .build();
+    }
+
+    public static OAuth2CallbackResponse link(OAuth2LinkResponse result) {
+        return OAuth2CallbackResponse.builder()
+                .type("link")
+                .linkData(LinkData.builder()
+                        .success(result.isSuccess())
+                        .platform(result.getPlatform())
+                        .email(result.getEmail())
+                        .message(result.getMessage())
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/service/OAuth2Service.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/OAuth2Service.java
@@ -15,7 +15,6 @@ import ceos.diggindie.domain.member.entity.Member;
 import ceos.diggindie.domain.member.entity.SocialAccount;
 import ceos.diggindie.domain.member.repository.MemberRepository;
 import ceos.diggindie.domain.member.repository.SocialAccountRepository;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,13 +44,12 @@ public class OAuth2Service {
     @Value("${jwt.refresh-token-validity}")
     private java.time.Duration refreshTokenValidity;
 
-    /**
-     * 소셜 로그인 (회원가입 포함)
-     */
     public OAuth2LoginResponse login(OAuth2LoginRequest request, HttpServletResponse response) {
-        validateState(request.getState(), request.getPlatform());
+        OAuth2StateService.StateInfo stateInfo = validateStateForLogin(request.getState());
 
-        OAuth2UserInfo userInfo = oAuth2Client.getUserInfo(request.getPlatform(), request.getCode());
+        LoginPlatform platform = LoginPlatform.valueOf(stateInfo.platform());
+
+        OAuth2UserInfo userInfo = oAuth2Client.getUserInfo(platform, request.getCode());
 
         LoginResult result = transactionTemplate.execute(status -> {
             Optional<SocialAccount> existingSocialAccount = socialAccountRepository
@@ -89,20 +87,20 @@ public class OAuth2Service {
                 .build();
     }
 
-    /**
-     * 기존 계정에 소셜 계정 연동
-     */
     public OAuth2LinkResponse linkSocialAccount(CustomUserDetails userDetails, OAuth2LinkRequest request) {
-        validateState(request.getState(), request.getPlatform());
+
+        OAuth2StateService.StateInfo stateInfo = validateStateForLink(request.getState());
+
+        LoginPlatform platform = LoginPlatform.valueOf(stateInfo.platform());
         Long memberId = userDetails.getMemberId();
 
         transactionTemplate.executeWithoutResult(status -> {
-            if (socialAccountRepository.existsByMemberIdAndPlatform(memberId, request.getPlatform())) {
+            if (socialAccountRepository.existsByMemberIdAndPlatform(memberId, platform)) {
                 throw new BusinessException(BusinessErrorCode.OAUTH_ALREADY_LINKED);
             }
         });
 
-        OAuth2UserInfo userInfo = oAuth2Client.getUserInfo(request.getPlatform(), request.getCode());
+        OAuth2UserInfo userInfo = oAuth2Client.getUserInfo(platform, request.getCode());
 
         transactionTemplate.executeWithoutResult(status -> {
             if (socialAccountRepository.findByPlatformAndPlatformId(
@@ -130,14 +128,9 @@ public class OAuth2Service {
                 .build();
     }
 
-    /**
-     * 소셜 계정 연동 해제
-     */
+
     @Transactional
     public OAuth2UnlinkResponse unlinkSocialAccount(CustomUserDetails userDetails, LoginPlatform platform) {
-        if (platform == LoginPlatform.LOCAL) {
-            throw new BusinessException(BusinessErrorCode.OAUTH_INVALID_PLATFORM, "기본 회원가입은 연동 해제할 수 없습니다.");
-        }
 
         Member member = memberRepository.findById(userDetails.getMemberId())
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND, "회원을 찾을 수 없습니다."));
@@ -162,9 +155,6 @@ public class OAuth2Service {
                 .build();
     }
 
-    /**
-     * 연동된 소셜 계정 목록 조회
-     */
     @Transactional(readOnly = true)
     public LinkedSocialAccountResponse getLinkedAccounts(CustomUserDetails userDetails) {
         List<SocialAccount> socialAccounts = socialAccountRepository
@@ -183,13 +173,10 @@ public class OAuth2Service {
                 .build();
     }
 
-    /**
-     * OAuth2 인증 URL 조회
-     */
-    public OAuth2UrlResponse getAuthUrl(LoginPlatform platform) {
+    public OAuth2UrlResponse getAuthUrl(LoginPlatform platform, String purpose) {
         OAuth2Properties.Provider provider = oAuth2Properties.getProvider(platform.name());
 
-        String state = oAuth2StateService.generateState(platform.name());
+        String state = oAuth2StateService.generateState(platform.name(), purpose);
 
         String authUrl = switch (platform) {
             case KAKAO -> String.format(
@@ -230,7 +217,7 @@ public class OAuth2Service {
     private void setRefreshToken(HttpServletResponse response, String externalId, Role role) {
         String refreshToken = jwtTokenProvider.generateRefreshToken(externalId, role);
         refreshTokenService.save(externalId, refreshToken);
-        addTokenCookie(response, "refresh_token", refreshToken, refreshTokenValidity);
+        addTokenCookie(response, "refreshToken", refreshToken, refreshTokenValidity);
     }
 
     private void addTokenCookie(HttpServletResponse response, String name, String value, java.time.Duration maxAge) {
@@ -244,13 +231,37 @@ public class OAuth2Service {
         response.addHeader("Set-Cookie", cookie.toString());
     }
 
-    private void validateState(String state, LoginPlatform platform) {
-        if (!oAuth2StateService.validateAndConsume(state, platform.name())) {
-            log.warn("OAuth state validation failed - state: {}, platform: {}", state, platform);
+    private OAuth2StateService.StateInfo validateStateForLogin(String state) {
+        OAuth2StateService.StateInfo stateInfo = oAuth2StateService.validateAndConsume(state);
+
+        if (stateInfo == null) {
+            log.warn("OAuth state validation failed - state: {}", state);
             throw new BusinessException(BusinessErrorCode.OAUTH_INVALID_STATE);
         }
+
+        if (!stateInfo.isLogin()) {
+            log.warn("OAuth state purpose mismatch - expected: login, actual: {}", stateInfo.purpose());
+            throw new BusinessException(BusinessErrorCode.OAUTH_INVALID_STATE, "로그인용 인증 URL이 아닙니다.");
+        }
+
+        return stateInfo;
     }
 
-    // 내부용 record
+    private OAuth2StateService.StateInfo validateStateForLink(String state) {
+        OAuth2StateService.StateInfo stateInfo = oAuth2StateService.validateAndConsume(state);
+
+        if (stateInfo == null) {
+            log.warn("OAuth state validation failed - state: {}", state);
+            throw new BusinessException(BusinessErrorCode.OAUTH_INVALID_STATE);
+        }
+
+        if (!stateInfo.isLink()) {
+            log.warn("OAuth state purpose mismatch - expected: link, actual: {}", stateInfo.purpose());
+            throw new BusinessException(BusinessErrorCode.OAUTH_INVALID_STATE, "계정 연동용 인증 URL이 아닙니다.");
+        }
+
+        return stateInfo;
+    }
+
     private record LoginResult(Member member, boolean isNewMember) {}
 }


### PR DESCRIPTION
## 🛰️ Issue Number
close #208

## 🪐 작업 내용

### 1. OAuth2 로그인/연동 API 통합
- 기존 분리된 `/auth/oauth2/login`과 `/auth/oauth2/link` API를 `/auth/oauth2/callback` 하나로 통합
- state에 `purpose` 정보(login/link)를 저장하여 백엔드에서 자동 분기 처리
- 프론트엔드 콜백 페이지에서 로그인/연동 구분 로직 불필요

### 2. OAuth2StateService 개선
- `generateState(platform)` → `generateState(platform, purpose)` 변경
- Redis에 `KAKAO:login`, `GOOGLE:link` 형태로 저장
- `StateInfo` record 추가로 platform과 purpose 파싱

### 3. 새로운 DTO 추가
- `OAuth2CallbackRequest`: 통합 콜백 요청 DTO
- `OAuth2CallbackResponse`: 로그인/연동 결과를 type으로 구분하여 반환

### 4. refreshToken 쿠키명 통일
- `refresh_token` → `refreshToken`으로 통일

## ⚠️ PR 특이 사항
- 프론트엔드에서 OAuth URL 요청 시 `purpose` 파라미터 필수 (`?purpose=login` 또는 `?purpose=link`)
- 연동(link) 시에는 반드시 Authorization 헤더에 토큰 포함 필요

## 📚 Reference

### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?