### PR TITLE
[FEAT] Mypage 관련 기능 개발 및 비밀번호 재설정 API 분리

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
     env_file:
       - .env
     environment:
@@ -26,6 +27,11 @@ services:
     command: ["redis-server", "--appendonly", "yes"]
     environment:
       TZ: Asia/Seoul
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
 volumes:
   redis-data:

--- a/src/main/java/ceos/diggindie/common/code/BusinessErrorCode.java
+++ b/src/main/java/ceos/diggindie/common/code/BusinessErrorCode.java
@@ -15,6 +15,8 @@ public enum BusinessErrorCode implements Code {
     DUPLICATE_NICKNAME(409, "이미 사용 중인 닉네임입니다."),
     RECENT_SEARCH_NOT_FOUND(404, "최근 검색어를 찾을 수 없습니다."),
     EMAIL_VERIFICATION_BLOCKED(429, "인증 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요."),
+    INVALID_RESET_TOKEN(401, "유효하지 않은 비밀번호 재설정 토큰입니다."),
+    PASSWORD_INVALID_FORMAT(400,  "비밀번호는 6~20자이며, 영문/숫자/특수문자 중 2가지 이상 조합이어야 합니다."),
 
     // ==================== 인증/토큰 ====================
     REFRESH_TOKEN_NOT_FOUND(401, "Refresh token이 존재하지 않습니다."),

--- a/src/main/java/ceos/diggindie/common/enums/EmailType.java
+++ b/src/main/java/ceos/diggindie/common/enums/EmailType.java
@@ -1,0 +1,17 @@
+package ceos.diggindie.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EmailType {
+
+    MSG_CODE_SENT("인증 코드가 발송되었습니다."),
+    MSG_SIGNUP_SUCCESS("이메일 인증이 완료되었습니다."),
+    MSG_PASSWORD_RESET_SUCCESS("인증이 완료되었습니다. 새 비밀번호를 설정해주세요."),
+    MSG_FIND_ID_SUCCESS("아이디 찾기가 완료되었습니다.")
+    ;
+
+    private final String description;
+}

--- a/src/main/java/ceos/diggindie/common/enums/PostType.java
+++ b/src/main/java/ceos/diggindie/common/enums/PostType.java
@@ -1,0 +1,6 @@
+package ceos.diggindie.common.enums;
+
+public enum PostType {
+    BOARD,   // 자유게시판
+    MARKET   // 거래게시판
+}

--- a/src/main/java/ceos/diggindie/domain/board/repository/BoardCommentRepository.java
+++ b/src/main/java/ceos/diggindie/domain/board/repository/BoardCommentRepository.java
@@ -1,6 +1,10 @@
 package ceos.diggindie.domain.board.repository;
 
+import ceos.diggindie.domain.board.entity.board.Board;
 import ceos.diggindie.domain.board.entity.board.BoardComment;
+import ceos.diggindie.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,4 +18,11 @@ public interface BoardCommentRepository extends JpaRepository<BoardComment, Long
             "WHERE c.board.id = :boardId AND c.parentComment IS NULL " +
             "ORDER BY c.createdAt ASC")
     List<BoardComment> findParentCommentsByBoardId(@Param("boardId") Long boardId);
+
+    @Query("""
+    SELECT DISTINCT b FROM BoardComment bc
+    JOIN bc.board b
+    WHERE bc.member = :member
+""")
+    Page<Board> findDistinctBoardsByMember(@Param("member") Member member, Pageable pageable);
 }

--- a/src/main/java/ceos/diggindie/domain/board/repository/BoardCommentRepository.java
+++ b/src/main/java/ceos/diggindie/domain/board/repository/BoardCommentRepository.java
@@ -19,10 +19,15 @@ public interface BoardCommentRepository extends JpaRepository<BoardComment, Long
             "ORDER BY c.createdAt ASC")
     List<BoardComment> findParentCommentsByBoardId(@Param("boardId") Long boardId);
 
-    @Query("""
-    SELECT DISTINCT b FROM BoardComment bc
-    JOIN bc.board b
-    WHERE bc.member = :member
-""")
+    @Query(value = """
+        SELECT bc.board FROM BoardComment bc
+        WHERE bc.member = :member
+        GROUP BY bc.board
+        ORDER BY MAX(bc.createdAt) DESC
+        """,
+            countQuery = """
+        SELECT COUNT(DISTINCT bc.board) FROM BoardComment bc
+        WHERE bc.member = :member
+        """)
     Page<Board> findDistinctBoardsByMember(@Param("member") Member member, Pageable pageable);
 }

--- a/src/main/java/ceos/diggindie/domain/board/repository/BoardLikeRepository.java
+++ b/src/main/java/ceos/diggindie/domain/board/repository/BoardLikeRepository.java
@@ -1,7 +1,13 @@
 package ceos.diggindie.domain.board.repository;
 
+import ceos.diggindie.domain.board.entity.board.Board;
 import ceos.diggindie.domain.board.entity.board.BoardLike;
+import ceos.diggindie.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,4 +18,12 @@ public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
     boolean existsByMemberIdAndBoardId(Long memberId, Long boardId);
 
     long countByBoardId(Long boardId);
+
+    @Query("""
+    SELECT b FROM BoardLike bl
+    JOIN bl.board b
+    WHERE bl.member = :member
+""")
+    Page<Board> findBoardsByMember(@Param("member") Member member, Pageable pageable);
+
 }

--- a/src/main/java/ceos/diggindie/domain/board/repository/BoardRepository.java
+++ b/src/main/java/ceos/diggindie/domain/board/repository/BoardRepository.java
@@ -2,6 +2,7 @@ package ceos.diggindie.domain.board.repository;
 
 import ceos.diggindie.common.enums.BoardCategory;
 import ceos.diggindie.domain.board.entity.board.Board;
+import ceos.diggindie.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -35,4 +36,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Page<Board> findByCategoryAndQueryWithImages(@Param("category") BoardCategory category,
                                                  @Param("query") String query,
                                                  Pageable pageable);
+
+    Page<Board> findByMemberOrderByCreatedAtDesc(Member member, Pageable pageable);
+
 }

--- a/src/main/java/ceos/diggindie/domain/board/repository/MarketRepository.java
+++ b/src/main/java/ceos/diggindie/domain/board/repository/MarketRepository.java
@@ -2,6 +2,7 @@ package ceos.diggindie.domain.board.repository;
 
 import ceos.diggindie.common.enums.MarketType;
 import ceos.diggindie.domain.board.entity.market.Market;
+import ceos.diggindie.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -43,4 +44,7 @@ public interface MarketRepository extends JpaRepository<Market, Long> {
             "ORDER BY m.createdAt DESC",
             countQuery = "SELECT COUNT(m) FROM Market m WHERE m.type = :type AND (m.title ILIKE %:query% OR m.content ILIKE %:query%)")
     Page<Market> findByTypeAndQueryWithImages(@Param("type") MarketType type, @Param("query") String query, Pageable pageable);
+
+    Page<Market> findByMemberOrderByCreatedAtDesc(Member member, Pageable pageable);
+
 }

--- a/src/main/java/ceos/diggindie/domain/board/repository/MarketScrapRepository.java
+++ b/src/main/java/ceos/diggindie/domain/board/repository/MarketScrapRepository.java
@@ -1,7 +1,13 @@
 package ceos.diggindie.domain.board.repository;
 
+import ceos.diggindie.domain.board.entity.market.Market;
 import ceos.diggindie.domain.board.entity.market.MarketScrap;
 import org.springframework.data.jpa.repository.JpaRepository;
+import ceos.diggindie.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,4 +18,11 @@ public interface MarketScrapRepository extends JpaRepository<MarketScrap, Long> 
     boolean existsByMemberIdAndMarketId(Long memberId, Long marketId);
 
     long countByMarketId(Long marketId);
+
+    @Query("""
+    SELECT m FROM MarketScrap ms
+    JOIN ms.market m
+    WHERE ms.member = :member
+""")
+    Page<Market> findMarketsByMember(@Param("member") Member member, Pageable pageable);
 }

--- a/src/main/java/ceos/diggindie/domain/member/controller/AuthController.java
+++ b/src/main/java/ceos/diggindie/domain/member/controller/AuthController.java
@@ -7,6 +7,7 @@ import ceos.diggindie.common.response.Response;
 import ceos.diggindie.domain.member.dto.*;
 import ceos.diggindie.domain.member.dto.oauth.*;
 import ceos.diggindie.domain.member.service.AuthService;
+import ceos.diggindie.domain.member.service.EmailService;
 import ceos.diggindie.domain.member.service.MemberService;
 import ceos.diggindie.domain.member.service.OAuth2Service;
 import io.swagger.v3.oas.annotations.Operation;
@@ -31,6 +32,7 @@ public class AuthController {
     private final AuthService authService;
     private final OAuth2Service oAuth2Service;
     private final MemberService memberService;
+    private final EmailService emailService;
 
     @Operation(summary = "회원가입", description = "새로운 회원을 등록합니다.")
     @ApiResponses({
@@ -255,4 +257,22 @@ public class AuthController {
         return ResponseEntity.ok().body(response);
     }
 
+    @Operation(
+            summary = "비밀번호 재설정",
+            description = "이메일 인증 후 발급받은 resetToken으로 비밀번호를 변경합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 토큰 또는 비밀번호 형식 오류"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 이메일")
+    })
+    @PostMapping("/auth/password/reset")
+    public ResponseEntity<Response<String>> resetPassword(
+            @Valid @RequestBody PasswordResetRequest request
+    ) {
+        emailService.resetPassword(request);
+        return ResponseEntity.ok(
+                Response.success(SuccessCode.UPDATE_SUCCESS, "비밀번호가 변경되었습니다.")
+        );
+    }
 }

--- a/src/main/java/ceos/diggindie/domain/member/controller/EmailController.java
+++ b/src/main/java/ceos/diggindie/domain/member/controller/EmailController.java
@@ -44,7 +44,7 @@ public class EmailController {
 
     @Operation(
             summary = "인증 코드 확인",
-            description = "인증 코드를 확인합니다. PASSWORD_RESET은 newPassword 필수, FIND_USER_ID는 마스킹된 아이디 반환"
+            description = "인증 코드를 확인합니다. PASSWORD_RESET은 resetToken 반환, FIND_USER_ID는 마스킹된 아이디 반환"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "인증 성공"),

--- a/src/main/java/ceos/diggindie/domain/member/controller/MyPageController.java
+++ b/src/main/java/ceos/diggindie/domain/member/controller/MyPageController.java
@@ -1,0 +1,117 @@
+package ceos.diggindie.domain.member.controller;
+
+import ceos.diggindie.common.code.SuccessCode;
+import ceos.diggindie.common.config.security.CustomUserDetails;
+import ceos.diggindie.common.response.Response;
+import ceos.diggindie.domain.member.dto.mypage.*;
+import ceos.diggindie.domain.member.service.MyPageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "MyPage", description = "마이페이지 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/my")
+@PreAuthorize("isAuthenticated()")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    private static final String SORT_PROPERTY = "createdAt";
+
+    @Operation(summary = "내가 쓴 자유게시판 글 조회")
+    @GetMapping("/posts/board")
+    public ResponseEntity<Response<List<MyBoardPostResponse>>> getMyBoardPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(SORT_PROPERTY).descending());
+
+        Response<List<MyBoardPostResponse>> response = Response.success(
+                SuccessCode.GET_SUCCESS,
+                myPageService.getMyBoardPosts(userDetails.getExternalId(), pageable),
+                "마이페이지 내가 쓴 자유게시판 글 API"
+        );
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "내가 쓴 마켓 글 조회")
+    @GetMapping("/posts/market")
+    public ResponseEntity<Response<List<MyMarketPostResponse>>> getMyMarketPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(SORT_PROPERTY).descending());
+
+        Response<List<MyMarketPostResponse>> response = Response.success(
+                SuccessCode.GET_SUCCESS,
+                myPageService.getMyMarketPosts(userDetails.getExternalId(), pageable),
+                "마이페이지 내가 쓴 마켓 글 API"
+        );
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "내가 댓글 단 게시물 조회 (자유게시판)")
+    @GetMapping("/comments")
+    public ResponseEntity<Response<List<MyCommentedPostResponse>>> getMyCommentedPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(SORT_PROPERTY).descending());
+
+        Response<List<MyCommentedPostResponse>> response = Response.success(
+                SuccessCode.GET_SUCCESS,
+                myPageService.getMyCommentedPosts(userDetails.getExternalId(), pageable),
+                "마이페이지 내가 댓글 단 게시물 API"
+        );
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "좋아요한 게시물 조회 (자유게시판)")
+    @GetMapping("/likes")
+    public ResponseEntity<Response<List<MyLikedPostResponse>>> getMyLikedPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(SORT_PROPERTY).descending());
+
+        Response<List<MyLikedPostResponse>> response = Response.success(
+                SuccessCode.GET_SUCCESS,
+                myPageService.getMyLikedPosts(userDetails.getExternalId(), pageable),
+                "마이페이지 좋아요한 게시물 API"
+        );
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "스크랩한 게시물 조회 (거래게시판)")
+    @GetMapping("/scraps")
+    public ResponseEntity<Response<List<MyScrappedPostResponse>>> getMyScrappedPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(SORT_PROPERTY).descending());
+
+        Response<List<MyScrappedPostResponse>> response = Response.success(
+                SuccessCode.GET_SUCCESS,
+                myPageService.getMyScrappedPosts(userDetails.getExternalId(), pageable),
+                "마이페이지 스크랩한 게시물 API"
+        );
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/controller/MyPageController.java
+++ b/src/main/java/ceos/diggindie/domain/member/controller/MyPageController.java
@@ -71,7 +71,7 @@ public class MyPageController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by(SORT_PROPERTY).descending());
+        Pageable pageable = PageRequest.of(page, size);
 
         Response<List<MyCommentedPostResponse>> response = Response.success(
                 SuccessCode.GET_SUCCESS,

--- a/src/main/java/ceos/diggindie/domain/member/dto/PasswordResetRequest.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/PasswordResetRequest.java
@@ -1,0 +1,10 @@
+package ceos.diggindie.domain.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordResetRequest(
+        @NotBlank @Email String email,
+        @NotBlank String resetToken,
+        @NotBlank String newPassword
+) {}

--- a/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerificationResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerificationResponse.java
@@ -1,19 +1,19 @@
 package ceos.diggindie.domain.member.dto.email;
 
+import ceos.diggindie.common.enums.EmailType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalDateTime;
 
+import static ceos.diggindie.common.enums.EmailType.*;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record EmailVerificationResponse(
-        String message,
+        EmailType message,
         String resetToken,      // PASSWORD_RESET용
         String maskedUserId,    // FIND_USER_ID용
         LocalDateTime createdAt // FIND_USER_ID용
 ) {
-    private static final String MSG_CODE_SENT = "인증 코드가 발송되었습니다.";
-    private static final String MSG_SIGNUP_SUCCESS = "이메일 인증이 완료되었습니다.";
-    private static final String MSG_PASSWORD_RESET_SUCCESS = "인증이 완료되었습니다. 새 비밀번호를 설정해주세요.";
-    private static final String MSG_FIND_ID_SUCCESS = "아이디 찾기가 완료되었습니다.";
+
 
     public static EmailVerificationResponse codeSent() {
         return new EmailVerificationResponse(MSG_CODE_SENT, null, null, null);

--- a/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerificationResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerificationResponse.java
@@ -1,18 +1,28 @@
 package ceos.diggindie.domain.member.dto.email;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.time.LocalDateTime;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record EmailVerificationResponse(
         String message,
-        boolean success,
-        String userId,  // FIND_USER_ID일 때만 반환
-        LocalDateTime createdAt
+        String resetToken,      // PASSWORD_RESET용
+        String maskedUserId,    // FIND_USER_ID용
+        LocalDateTime createdAt // FIND_USER_ID용
 ) {
-    public EmailVerificationResponse(String message, boolean success) {
-        this(message, success, null, null);
+    // 기본 응답 (SIGNUP 등)
+    public EmailVerificationResponse(String message) {
+        this(message, null, null, null);
     }
 
-    public EmailVerificationResponse(String message, boolean success, String userId) {
-        this(message, success, userId, null);
+    // PASSWORD_RESET용
+    public static EmailVerificationResponse forPasswordReset(String message, String resetToken) {
+        return new EmailVerificationResponse(message, resetToken, null, null);
+    }
+
+    // FIND_USER_ID용
+    public static EmailVerificationResponse forFindUserId(String message, String maskedUserId, LocalDateTime createdAt) {
+        return new EmailVerificationResponse(message, null, maskedUserId, createdAt);
     }
 }

--- a/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerificationResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerificationResponse.java
@@ -1,7 +1,6 @@
 package ceos.diggindie.domain.member.dto.email;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-
 import java.time.LocalDateTime;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -11,18 +10,27 @@ public record EmailVerificationResponse(
         String maskedUserId,    // FIND_USER_ID용
         LocalDateTime createdAt // FIND_USER_ID용
 ) {
-    // 기본 응답 (SIGNUP 등)
-    public EmailVerificationResponse(String message) {
-        this(message, null, null, null);
+    private static final String MSG_CODE_SENT = "인증 코드가 발송되었습니다.";
+    private static final String MSG_SIGNUP_SUCCESS = "이메일 인증이 완료되었습니다.";
+    private static final String MSG_PASSWORD_RESET_SUCCESS = "인증이 완료되었습니다. 새 비밀번호를 설정해주세요.";
+    private static final String MSG_FIND_ID_SUCCESS = "아이디 찾기가 완료되었습니다.";
+
+    public static EmailVerificationResponse codeSent() {
+        return new EmailVerificationResponse(MSG_CODE_SENT, null, null, null);
     }
 
-    // PASSWORD_RESET용
-    public static EmailVerificationResponse forPasswordReset(String message, String resetToken) {
-        return new EmailVerificationResponse(message, resetToken, null, null);
+    // 회원가입 등 기본 인증 성공 (SIGNUP)
+    public static EmailVerificationResponse successSignup() {
+        return new EmailVerificationResponse(MSG_SIGNUP_SUCCESS, null, null, null);
     }
 
-    // FIND_USER_ID용
-    public static EmailVerificationResponse forFindUserId(String message, String maskedUserId, LocalDateTime createdAt) {
-        return new EmailVerificationResponse(message, null, maskedUserId, createdAt);
+    // 비밀번호 재설정용 (PASSWORD_RESET)
+    public static EmailVerificationResponse successPasswordReset(String resetToken) {
+        return new EmailVerificationResponse(MSG_PASSWORD_RESET_SUCCESS, resetToken, null, null);
+    }
+
+    // 아이디 찾기용 (FIND_USER_ID)
+    public static EmailVerificationResponse successFindUserId(String maskedUserId, LocalDateTime createdAt) {
+        return new EmailVerificationResponse(MSG_FIND_ID_SUCCESS, null, maskedUserId, createdAt);
     }
 }

--- a/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerifyRequest.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerifyRequest.java
@@ -15,8 +15,5 @@ public record EmailVerifyRequest(
         String code,
 
         @NotNull(message = "인증 타입은 필수입니다.")
-        EmailVerificationType type,
-
-        @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
-        String newPassword  // PASSWORD_RESET일 때만 필수
+        EmailVerificationType type
 ) {}

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyBoardPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyBoardPostResponse.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
 @Builder
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record MyBoardPostResponse(
         Long boardId,
         String category,
@@ -20,7 +19,7 @@ public record MyBoardPostResponse(
     public static MyBoardPostResponse from(Board board) {
         return MyBoardPostResponse.builder()
                 .boardId(board.getId())
-                .category(board.getCategory() != null ? board.getCategory().name() : null)
+                .category(board.getCategory() != null ? board.getCategory().getDescription() : null)
                 .title(board.getTitle())
                 .content(board.getContent())
                 .views(board.getViews())

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyBoardPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyBoardPostResponse.java
@@ -1,0 +1,32 @@
+package ceos.diggindie.domain.member.dto.mypage;
+
+import ceos.diggindie.common.utils.TimeUtils;
+import ceos.diggindie.domain.board.entity.board.Board;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MyBoardPostResponse(
+        Long boardId,
+        String category,
+        String title,
+        String content,
+        int views,
+        int likeCount,
+        int imageCount,
+        String createdAt
+) {
+    public static MyBoardPostResponse from(Board board) {
+        return MyBoardPostResponse.builder()
+                .boardId(board.getId())
+                .category(board.getCategory() != null ? board.getCategory().name() : null)
+                .title(board.getTitle())
+                .content(board.getContent())
+                .views(board.getViews())
+                .likeCount(board.getBoardLikes().size())
+                .imageCount(board.getBoardImages() != null ? board.getBoardImages().size() : 0)
+                .createdAt(TimeUtils.toRelativeTime(board.getCreatedAt()))
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyCommentedPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyCommentedPostResponse.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
 @Builder
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record MyCommentedPostResponse(
         Long boardId,
         String category,
@@ -20,7 +19,7 @@ public record MyCommentedPostResponse(
     public static MyCommentedPostResponse from(Board board) {
         return MyCommentedPostResponse.builder()
                 .boardId(board.getId())
-                .category(board.getCategory() != null ? board.getCategory().name() : null)
+                .category(board.getCategory() != null ? board.getCategory().getDescription() : null)
                 .title(board.getTitle())
                 .content(board.getContent())
                 .views(board.getViews())

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyCommentedPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyCommentedPostResponse.java
@@ -1,0 +1,32 @@
+package ceos.diggindie.domain.member.dto.mypage;
+
+import ceos.diggindie.common.utils.TimeUtils;
+import ceos.diggindie.domain.board.entity.board.Board;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MyCommentedPostResponse(
+        Long boardId,
+        String category,
+        String title,
+        String content,
+        int views,
+        int likeCount,
+        int imageCount,
+        String createdAt
+) {
+    public static MyCommentedPostResponse from(Board board) {
+        return MyCommentedPostResponse.builder()
+                .boardId(board.getId())
+                .category(board.getCategory() != null ? board.getCategory().name() : null)
+                .title(board.getTitle())
+                .content(board.getContent())
+                .views(board.getViews())
+                .likeCount(board.getBoardLikes().size())
+                .imageCount(board.getBoardImages() != null ? board.getBoardImages().size() : 0)
+                .createdAt(TimeUtils.toRelativeTime(board.getCreatedAt()))
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyCommentedPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyCommentedPostResponse.java
@@ -2,7 +2,6 @@ package ceos.diggindie.domain.member.dto.mypage;
 
 import ceos.diggindie.common.utils.TimeUtils;
 import ceos.diggindie.domain.board.entity.board.Board;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
 @Builder
@@ -11,6 +10,7 @@ public record MyCommentedPostResponse(
         String category,
         String title,
         String content,
+        String thumbnailUrl,
         int views,
         int likeCount,
         int imageCount,
@@ -22,6 +22,9 @@ public record MyCommentedPostResponse(
                 .category(board.getCategory() != null ? board.getCategory().getDescription() : null)
                 .title(board.getTitle())
                 .content(board.getContent())
+                .thumbnailUrl(board.getBoardImages() != null && !board.getBoardImages().isEmpty()
+                        ? board.getBoardImages().get(0).getImageUrl()
+                        : null)
                 .views(board.getViews())
                 .likeCount(board.getBoardLikes().size())
                 .imageCount(board.getBoardImages() != null ? board.getBoardImages().size() : 0)

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyLikedPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyLikedPostResponse.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
 @Builder
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record MyLikedPostResponse(
         Long boardId,
         String category,
@@ -20,7 +19,7 @@ public record MyLikedPostResponse(
     public static MyLikedPostResponse from(Board board) {
         return MyLikedPostResponse.builder()
                 .boardId(board.getId())
-                .category(board.getCategory() != null ? board.getCategory().name() : null)
+                .category(board.getCategory() != null ? board.getCategory().getDescription() : null)
                 .title(board.getTitle())
                 .content(board.getContent())
                 .views(board.getViews())

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyLikedPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyLikedPostResponse.java
@@ -2,7 +2,6 @@ package ceos.diggindie.domain.member.dto.mypage;
 
 import ceos.diggindie.common.utils.TimeUtils;
 import ceos.diggindie.domain.board.entity.board.Board;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
 @Builder
@@ -11,6 +10,7 @@ public record MyLikedPostResponse(
         String category,
         String title,
         String content,
+        String thumbnailUrl,
         int views,
         int likeCount,
         int imageCount,
@@ -22,6 +22,9 @@ public record MyLikedPostResponse(
                 .category(board.getCategory() != null ? board.getCategory().getDescription() : null)
                 .title(board.getTitle())
                 .content(board.getContent())
+                .thumbnailUrl(board.getBoardImages() != null && !board.getBoardImages().isEmpty()
+                        ? board.getBoardImages().get(0).getImageUrl()
+                        : null)
                 .views(board.getViews())
                 .likeCount(board.getBoardLikes().size())
                 .imageCount(board.getBoardImages() != null ? board.getBoardImages().size() : 0)

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyLikedPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyLikedPostResponse.java
@@ -1,0 +1,32 @@
+package ceos.diggindie.domain.member.dto.mypage;
+
+import ceos.diggindie.common.utils.TimeUtils;
+import ceos.diggindie.domain.board.entity.board.Board;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MyLikedPostResponse(
+        Long boardId,
+        String category,
+        String title,
+        String content,
+        int views,
+        int likeCount,
+        int imageCount,
+        String createdAt
+) {
+    public static MyLikedPostResponse from(Board board) {
+        return MyLikedPostResponse.builder()
+                .boardId(board.getId())
+                .category(board.getCategory() != null ? board.getCategory().name() : null)
+                .title(board.getTitle())
+                .content(board.getContent())
+                .views(board.getViews())
+                .likeCount(board.getBoardLikes().size())
+                .imageCount(board.getBoardImages() != null ? board.getBoardImages().size() : 0)
+                .createdAt(TimeUtils.toRelativeTime(board.getCreatedAt()))
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyMarketPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyMarketPostResponse.java
@@ -2,9 +2,7 @@ package ceos.diggindie.domain.member.dto.mypage;
 
 import ceos.diggindie.common.utils.TimeUtils;
 import ceos.diggindie.domain.board.entity.market.Market;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
-import org.yaml.snakeyaml.error.Mark;
 
 @Builder
 public record MyMarketPostResponse(

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyMarketPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyMarketPostResponse.java
@@ -4,9 +4,9 @@ import ceos.diggindie.common.utils.TimeUtils;
 import ceos.diggindie.domain.board.entity.market.Market;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
+import org.yaml.snakeyaml.error.Mark;
 
 @Builder
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record MyMarketPostResponse(
         Long marketId,
         String category,
@@ -16,10 +16,10 @@ public record MyMarketPostResponse(
         int scrapCount,
         String createdAt
 ) {
-    public static MyMarketPostResponse from(ceos.diggindie.domain.board.entity.market.Market market) {
+    public static MyMarketPostResponse from(Market market) {
         return MyMarketPostResponse.builder()
                 .marketId(market.getId())
-                .category(market.getType() != null ? market.getType().name() : null)
+                .category(market.getType() != null ? market.getType().getDisplayName() : null)
                 .title(market.getTitle())
                 .price(market.getPrice())
                 .thumbnailUrl(market.getMarketImages() != null && !market.getMarketImages().isEmpty()

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyMarketPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyMarketPostResponse.java
@@ -1,0 +1,32 @@
+package ceos.diggindie.domain.member.dto.mypage;
+
+import ceos.diggindie.common.utils.TimeUtils;
+import ceos.diggindie.domain.board.entity.market.Market;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MyMarketPostResponse(
+        Long marketId,
+        String category,
+        String title,
+        Integer price,
+        String thumbnailUrl,
+        int scrapCount,
+        String createdAt
+) {
+    public static MyMarketPostResponse from(ceos.diggindie.domain.board.entity.market.Market market) {
+        return MyMarketPostResponse.builder()
+                .marketId(market.getId())
+                .category(market.getType() != null ? market.getType().name() : null)
+                .title(market.getTitle())
+                .price(market.getPrice())
+                .thumbnailUrl(market.getMarketImages() != null && !market.getMarketImages().isEmpty()
+                        ? market.getMarketImages().get(0).getImageUrl()
+                        : null)
+                .scrapCount(market.getMarketScraps().size())
+                .createdAt(TimeUtils.toRelativeTime(market.getCreatedAt()))
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyScrappedPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyScrappedPostResponse.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
 @Builder
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record MyScrappedPostResponse(
         Long marketId,
         String category,
@@ -19,7 +18,7 @@ public record MyScrappedPostResponse(
     public static MyScrappedPostResponse from(Market market) {
         return MyScrappedPostResponse.builder()
                 .marketId(market.getId())
-                .category(market.getType() != null ? market.getType().name() : null)
+                .category(market.getType() != null ? market.getType().getDisplayName() : null)
                 .title(market.getTitle())
                 .price(market.getPrice())
                 .thumbnailUrl(market.getMarketImages() != null && !market.getMarketImages().isEmpty()

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyScrappedPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyScrappedPostResponse.java
@@ -1,0 +1,32 @@
+package ceos.diggindie.domain.member.dto.mypage;
+
+import ceos.diggindie.common.utils.TimeUtils;
+import ceos.diggindie.domain.board.entity.market.Market;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MyScrappedPostResponse(
+        Long marketId,
+        String category,
+        String title,
+        Integer price,
+        String thumbnailUrl,
+        int scrapCount,
+        String createdAt
+) {
+    public static MyScrappedPostResponse from(Market market) {
+        return MyScrappedPostResponse.builder()
+                .marketId(market.getId())
+                .category(market.getType() != null ? market.getType().name() : null)
+                .title(market.getTitle())
+                .price(market.getPrice())
+                .thumbnailUrl(market.getMarketImages() != null && !market.getMarketImages().isEmpty()
+                        ? market.getMarketImages().get(0).getImageUrl()
+                        : null)
+                .scrapCount(market.getMarketScraps().size())
+                .createdAt(TimeUtils.toRelativeTime(market.getCreatedAt()))
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/service/EmailService.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/EmailService.java
@@ -63,7 +63,7 @@ public class EmailService {
         saveCode(request.email(), code, request.type());
         sendVerificationEmail(request.email(), code, request.type());
 
-        return new EmailVerificationResponse("인증 코드가 발송되었습니다.");
+        return EmailVerificationResponse.codeSent();
     }
 
     @Transactional
@@ -82,24 +82,17 @@ public class EmailService {
         clearAttempt(request.email(), request.type());
 
         return switch (request.type()) {
-            case SIGNUP -> new EmailVerificationResponse("이메일 인증이 완료되었습니다.");
+            case SIGNUP -> EmailVerificationResponse.successSignup();
 
             case PASSWORD_RESET -> {
                 String resetToken = createResetToken(request.email());
-                yield EmailVerificationResponse.forPasswordReset(
-                        "인증이 완료되었습니다. 새 비밀번호를 설정해주세요.",
-                        resetToken
-                );
+                yield EmailVerificationResponse.successPasswordReset(resetToken);
             }
 
             case FIND_USER_ID -> {
                 Member member = findMemberByEmail(request.email());
                 String maskedUserId = maskUserId(member.getUserId());
-                yield EmailVerificationResponse.forFindUserId(
-                        "아이디 찾기가 완료되었습니다.",
-                        maskedUserId,
-                        member.getCreatedAt()
-                );
+                yield EmailVerificationResponse.successFindUserId(maskedUserId, member.getCreatedAt());
             }
         };
     }

--- a/src/main/java/ceos/diggindie/domain/member/service/EmailService.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/EmailService.java
@@ -3,6 +3,7 @@ package ceos.diggindie.domain.member.service;
 import ceos.diggindie.common.code.BusinessErrorCode;
 import ceos.diggindie.common.enums.EmailVerificationType;
 import ceos.diggindie.common.exception.BusinessException;
+import ceos.diggindie.domain.member.dto.PasswordResetRequest;
 import ceos.diggindie.domain.member.dto.email.EmailSendRequest;
 import ceos.diggindie.domain.member.dto.email.EmailVerifyRequest;
 import ceos.diggindie.domain.member.dto.email.EmailVerificationResponse;
@@ -22,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
 import java.time.Duration;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -38,6 +40,10 @@ public class EmailService {
     private static final String ATTEMPT_PREFIX = "email_attempt:";
     private static final long CODE_VALIDITY_MINUTES = 5;
     private static final int MAX_ATTEMPTS = 5;
+
+    private static final String RESET_TOKEN_PREFIX = "password_reset:";
+    private static final long RESET_TOKEN_VALIDITY_MINUTES = 10;
+
 
     public EmailVerificationResponse sendVerificationCode(EmailSendRequest request) {
         switch (request.type()) {
@@ -57,7 +63,7 @@ public class EmailService {
         saveCode(request.email(), code, request.type());
         sendVerificationEmail(request.email(), code, request.type());
 
-        return new EmailVerificationResponse("인증 코드가 발송되었습니다.", true);
+        return new EmailVerificationResponse("인증 코드가 발송되었습니다.");
     }
 
     @Transactional
@@ -76,25 +82,21 @@ public class EmailService {
         clearAttempt(request.email(), request.type());
 
         return switch (request.type()) {
-            case SIGNUP -> new EmailVerificationResponse("이메일 인증이 완료되었습니다.", true);
+            case SIGNUP -> new EmailVerificationResponse("이메일 인증이 완료되었습니다.");
 
             case PASSWORD_RESET -> {
-                validateNewPassword(request.newPassword());
-                Member member = findMemberByEmail(request.email());
-                member.updatePassword(passwordEncoder.encode(request.newPassword()));
-
-                // 기존 리프레시 토큰 무효화
-                refreshTokenService.delete(member.getExternalId());
-
-                yield new EmailVerificationResponse("비밀번호가 변경되었습니다. 다시 로그인해주세요.", true);
+                String resetToken = createResetToken(request.email());
+                yield EmailVerificationResponse.forPasswordReset(
+                        "인증이 완료되었습니다. 새 비밀번호를 설정해주세요.",
+                        resetToken
+                );
             }
 
             case FIND_USER_ID -> {
                 Member member = findMemberByEmail(request.email());
                 String maskedUserId = maskUserId(member.getUserId());
-                yield new EmailVerificationResponse(
+                yield EmailVerificationResponse.forFindUserId(
                         "아이디 찾기가 완료되었습니다.",
-                        true,
                         maskedUserId,
                         member.getCreatedAt()
                 );
@@ -130,10 +132,22 @@ public class EmailService {
 
     private void validateNewPassword(String newPassword) {
         if (newPassword == null || newPassword.isBlank()) {
-            throw new BusinessException(BusinessErrorCode.PASSWORD_TOO_SHORT);
+            throw new BusinessException(BusinessErrorCode.PASSWORD_INVALID_FORMAT);
         }
-        if (newPassword.length() < 8) {
-            throw new BusinessException(BusinessErrorCode.PASSWORD_TOO_SHORT);
+
+        // 길이 체크: 6~20자
+        if (newPassword.length() < 6 || newPassword.length() > 20) {
+            throw new BusinessException(BusinessErrorCode.PASSWORD_INVALID_FORMAT);
+        }
+
+        // 2가지 이상 조합 체크
+        int typeCount = 0;
+        if (newPassword.matches(".*[a-zA-Z].*")) typeCount++;  // 영문
+        if (newPassword.matches(".*[0-9].*")) typeCount++;      // 숫자
+        if (newPassword.matches(".*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?].*")) typeCount++;  // 특수문자
+
+        if (typeCount < 2) {
+            throw new BusinessException(BusinessErrorCode.PASSWORD_INVALID_FORMAT);
         }
     }
 
@@ -217,4 +231,40 @@ public class EmailService {
         </html>
         """.formatted(type.getTitle(), type.getDescription(), type.getColor(), code);
     }
+
+    private String createResetToken(String email) {
+        String token = UUID.randomUUID().toString();
+        String key = RESET_TOKEN_PREFIX + email;
+        RBucket<String> bucket = redissonClient.getBucket(key);
+        bucket.set(token, RESET_TOKEN_VALIDITY_MINUTES, TimeUnit.MINUTES);
+        return token;
+    }
+
+    private void validateResetToken(String email, String token) {
+        String key = RESET_TOKEN_PREFIX + email;
+        RBucket<String> bucket = redissonClient.getBucket(key);
+        String stored = bucket.get();
+
+        if (stored == null || !stored.equals(token)) {
+            throw new BusinessException(BusinessErrorCode.INVALID_RESET_TOKEN);
+        }
+    }
+
+    @Transactional
+    public void resetPassword(PasswordResetRequest request) {
+        validateResetToken(request.email(), request.resetToken());
+        validateNewPassword(request.newPassword());
+
+        Member member = findMemberByEmail(request.email());
+        member.updatePassword(passwordEncoder.encode(request.newPassword()));
+
+        deleteResetToken(request.email());
+        refreshTokenService.delete(member.getExternalId());
+    }
+
+    private void deleteResetToken(String email) {
+        String key = RESET_TOKEN_PREFIX + email;
+        redissonClient.getBucket(key).delete();
+    }
+
 }

--- a/src/main/java/ceos/diggindie/domain/member/service/MemberService.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/MemberService.java
@@ -4,7 +4,6 @@ import ceos.diggindie.common.code.BusinessErrorCode;
 import ceos.diggindie.common.exception.BusinessException;
 import ceos.diggindie.domain.member.dto.MarketingConsentRequest;
 import ceos.diggindie.domain.member.dto.MarketingConsentResponse;
-import ceos.diggindie.domain.member.dto.PasswordResetRequest;
 import ceos.diggindie.domain.member.entity.Member;
 import ceos.diggindie.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/ceos/diggindie/domain/member/service/MemberService.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/MemberService.java
@@ -4,6 +4,7 @@ import ceos.diggindie.common.code.BusinessErrorCode;
 import ceos.diggindie.common.exception.BusinessException;
 import ceos.diggindie.domain.member.dto.MarketingConsentRequest;
 import ceos.diggindie.domain.member.dto.MarketingConsentResponse;
+import ceos.diggindie.domain.member.dto.PasswordResetRequest;
 import ceos.diggindie.domain.member.entity.Member;
 import ceos.diggindie.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,19 +23,6 @@ public class MemberService {
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.MEMBER_NOT_FOUND,
                         "회원을 찾을 수 없습니다."));
     }
-
-    public Member findByEmail(String email) {
-        return memberRepository.findByEmail(email)
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.MEMBER_NOT_FOUND,
-                        "회원을 찾을 수 없습니다."));
-    }
-
-    public Member findByUserId(String userId) {
-        return memberRepository.findByUserId(userId)
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.MEMBER_NOT_FOUND,
-                        "회원을 찾을 수 없습니다."));
-    }
-
 
     @Transactional
     public MarketingConsentResponse updateMarketingConsent(String externalId, MarketingConsentRequest request) {

--- a/src/main/java/ceos/diggindie/domain/member/service/MyPageService.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/MyPageService.java
@@ -1,0 +1,73 @@
+package ceos.diggindie.domain.member.service;
+
+import ceos.diggindie.common.code.BusinessErrorCode;
+import ceos.diggindie.common.enums.PostType;
+import ceos.diggindie.common.exception.BusinessException;
+import ceos.diggindie.domain.board.repository.*;
+import ceos.diggindie.domain.member.dto.mypage.*;
+import ceos.diggindie.domain.member.entity.Member;
+import ceos.diggindie.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageService {
+
+    private final MemberRepository memberRepository;
+    private final BoardRepository boardRepository;
+    private final MarketRepository marketRepository;
+    private final BoardCommentRepository boardCommentRepository;
+    private final BoardLikeRepository boardLikeRepository;
+    private final MarketScrapRepository marketScrapRepository;
+
+    // 내가 쓴 자유게시판 글 조회
+    public List<MyBoardPostResponse> getMyBoardPosts(String externalId, Pageable pageable) {
+        Member member = findMember(externalId);
+        return boardRepository.findByMemberOrderByCreatedAtDesc(member, pageable)
+                .map(MyBoardPostResponse::from)
+                .getContent();
+    }
+
+    // 내가 쓴 마켓 글 조회
+    public List<MyMarketPostResponse> getMyMarketPosts(String externalId, Pageable pageable) {
+        Member member = findMember(externalId);
+        return marketRepository.findByMemberOrderByCreatedAtDesc(member, pageable)
+                .map(MyMarketPostResponse::from)
+                .getContent();
+    }
+
+    // 내가 댓글 단 게시물 조회 (자유게시판)
+    public List<MyCommentedPostResponse> getMyCommentedPosts(String externalId, Pageable pageable) {
+        Member member = findMember(externalId);
+        return boardCommentRepository.findDistinctBoardsByMember(member, pageable)
+                .map(MyCommentedPostResponse::from)
+                .getContent();
+    }
+
+    // 좋아요한 게시물 조회 (자유게시판)
+    public List<MyLikedPostResponse> getMyLikedPosts(String externalId, Pageable pageable) {
+        Member member = findMember(externalId);
+        return boardLikeRepository.findBoardsByMember(member, pageable)
+                .map(MyLikedPostResponse::from)
+                .getContent();
+    }
+
+    // 스크랩한 양도글 조회 (거래게시판)
+    public List<MyScrappedPostResponse> getMyScrappedPosts(String externalId, Pageable pageable) {
+        Member member = findMember(externalId);
+        return marketScrapRepository.findMarketsByMember(member, pageable)
+                .map(MyScrappedPostResponse::from)
+                .getContent();
+    }
+
+    private Member findMember(String externalId) {
+        return memberRepository.findByExternalId(externalId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/service/MyPageService.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/MyPageService.java
@@ -8,6 +8,7 @@ import ceos.diggindie.domain.member.dto.mypage.*;
 import ceos.diggindie.domain.member.entity.Member;
 import ceos.diggindie.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,43 +28,38 @@ public class MyPageService {
     private final MarketScrapRepository marketScrapRepository;
 
     // 내가 쓴 자유게시판 글 조회
-    public List<MyBoardPostResponse> getMyBoardPosts(String externalId, Pageable pageable) {
+    public Page<MyBoardPostResponse> getMyBoardPosts(String externalId, Pageable pageable) {
         Member member = findMember(externalId);
         return boardRepository.findByMemberOrderByCreatedAtDesc(member, pageable)
-                .map(MyBoardPostResponse::from)
-                .getContent();
+                .map(MyBoardPostResponse::from);
     }
 
     // 내가 쓴 마켓 글 조회
-    public List<MyMarketPostResponse> getMyMarketPosts(String externalId, Pageable pageable) {
+    public Page<MyMarketPostResponse> getMyMarketPosts(String externalId, Pageable pageable) {
         Member member = findMember(externalId);
         return marketRepository.findByMemberOrderByCreatedAtDesc(member, pageable)
-                .map(MyMarketPostResponse::from)
-                .getContent();
+                .map(MyMarketPostResponse::from);
     }
 
     // 내가 댓글 단 게시물 조회 (자유게시판)
-    public List<MyCommentedPostResponse> getMyCommentedPosts(String externalId, Pageable pageable) {
+    public Page<MyCommentedPostResponse> getMyCommentedPosts(String externalId, Pageable pageable) {
         Member member = findMember(externalId);
         return boardCommentRepository.findDistinctBoardsByMember(member, pageable)
-                .map(MyCommentedPostResponse::from)
-                .getContent();
+                .map(MyCommentedPostResponse::from);
     }
 
     // 좋아요한 게시물 조회 (자유게시판)
-    public List<MyLikedPostResponse> getMyLikedPosts(String externalId, Pageable pageable) {
+    public Page<MyLikedPostResponse> getMyLikedPosts(String externalId, Pageable pageable) {
         Member member = findMember(externalId);
         return boardLikeRepository.findBoardsByMember(member, pageable)
-                .map(MyLikedPostResponse::from)
-                .getContent();
+                .map(MyLikedPostResponse::from);
     }
 
     // 스크랩한 양도글 조회 (거래게시판)
-    public List<MyScrappedPostResponse> getMyScrappedPosts(String externalId, Pageable pageable) {
+    public Page<MyScrappedPostResponse> getMyScrappedPosts(String externalId, Pageable pageable) {
         Member member = findMember(externalId);
         return marketScrapRepository.findMarketsByMember(member, pageable)
-                .map(MyScrappedPostResponse::from)
-                .getContent();
+                .map(MyScrappedPostResponse::from);
     }
 
     private Member findMember(String externalId) {


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->
<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #101

## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->

### 1. 비밀번호 재설정 API 분리
- 기존: 이메일 인증 시 바로 비밀번호 변경
- 변경: 이메일 인증 → `resetToken` 발급 → 별도 API로 비밀번호 변경
- `POST /auth/password/reset` 엔드포인트 추가
- 비밀번호 유효성 검증 수정 (6~20자, 영문/숫자/특수문자 중 2가지 이상 조합)

### 2. 마이페이지 관련 기능 개발
- `GET /my/posts/board` - 내가 쓴 자유게시판 글 조회
- `GET /my/posts/market` - 내가 쓴 마켓 글 조회
- `GET /my/comments` - 내가 댓글 단 게시물 조회
- `GET /my/likes` - 좋아요한 게시물 조회
- `GET /my/scraps` - 스크랩한 게시물 조회

### 3. 기타 수정사항
- Docker Compose: Redis healthcheck 추가 (앱 시작 전 Redis 준비 상태 확인)
- 이중정렬 문제 해결
- null인 항목 보이게 수정 (`@JsonInclude` 제거)

## ⚠️ PR 특이 사항
- `EmailVerifyRequest`에서 `newPassword` 필드 제거됨 → 프론트엔드 연동 시 확인 필요
- `EmailVerificationResponse` 응답 구조 변경
  - `success` 필드 제거
  - `userId` → `maskedUserId`로 변경
  - `resetToken` 필드 추가 (PASSWORD_RESET용)
- 비밀번호 재설정 플로우 변경으로 기존 연동 코드 수정 필요

## 📚 Reference

### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?