### PR TITLE
[FEAT] Mypage 관련 기능 개발 및 비밀번호 재설정 API 분리 (#113)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
     env_file:
       - .env
     environment:
@@ -26,6 +27,11 @@ services:
     command: ["redis-server", "--appendonly", "yes"]
     environment:
       TZ: Asia/Seoul
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
 volumes:
   redis-data:

--- a/src/main/java/ceos/diggindie/common/code/BusinessErrorCode.java
+++ b/src/main/java/ceos/diggindie/common/code/BusinessErrorCode.java
@@ -15,6 +15,8 @@ public enum BusinessErrorCode implements Code {
     DUPLICATE_NICKNAME(409, "이미 사용 중인 닉네임입니다."),
     RECENT_SEARCH_NOT_FOUND(404, "최근 검색어를 찾을 수 없습니다."),
     EMAIL_VERIFICATION_BLOCKED(429, "인증 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요."),
+    INVALID_RESET_TOKEN(401, "유효하지 않은 비밀번호 재설정 토큰입니다."),
+    PASSWORD_INVALID_FORMAT(400,  "비밀번호는 6~20자이며, 영문/숫자/특수문자 중 2가지 이상 조합이어야 합니다."),
 
     // ==================== 인증/토큰 ====================
     REFRESH_TOKEN_NOT_FOUND(401, "Refresh token이 존재하지 않습니다."),

--- a/src/main/java/ceos/diggindie/common/enums/EmailType.java
+++ b/src/main/java/ceos/diggindie/common/enums/EmailType.java
@@ -1,0 +1,17 @@
+package ceos.diggindie.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EmailType {
+
+    MSG_CODE_SENT("인증 코드가 발송되었습니다."),
+    MSG_SIGNUP_SUCCESS("이메일 인증이 완료되었습니다."),
+    MSG_PASSWORD_RESET_SUCCESS("인증이 완료되었습니다. 새 비밀번호를 설정해주세요."),
+    MSG_FIND_ID_SUCCESS("아이디 찾기가 완료되었습니다.")
+    ;
+
+    private final String description;
+}

--- a/src/main/java/ceos/diggindie/common/enums/PostType.java
+++ b/src/main/java/ceos/diggindie/common/enums/PostType.java
@@ -1,0 +1,6 @@
+package ceos.diggindie.common.enums;
+
+public enum PostType {
+    BOARD,   // 자유게시판
+    MARKET   // 거래게시판
+}

--- a/src/main/java/ceos/diggindie/domain/board/repository/BoardCommentRepository.java
+++ b/src/main/java/ceos/diggindie/domain/board/repository/BoardCommentRepository.java
@@ -1,6 +1,10 @@
 package ceos.diggindie.domain.board.repository;
 
+import ceos.diggindie.domain.board.entity.board.Board;
 import ceos.diggindie.domain.board.entity.board.BoardComment;
+import ceos.diggindie.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,4 +18,16 @@ public interface BoardCommentRepository extends JpaRepository<BoardComment, Long
             "WHERE c.board.id = :boardId AND c.parentComment IS NULL " +
             "ORDER BY c.createdAt ASC")
     List<BoardComment> findParentCommentsByBoardId(@Param("boardId") Long boardId);
+
+    @Query(value = """
+        SELECT bc.board FROM BoardComment bc
+        WHERE bc.member = :member
+        GROUP BY bc.board
+        ORDER BY MAX(bc.createdAt) DESC
+        """,
+            countQuery = """
+        SELECT COUNT(DISTINCT bc.board) FROM BoardComment bc
+        WHERE bc.member = :member
+        """)
+    Page<Board> findDistinctBoardsByMember(@Param("member") Member member, Pageable pageable);
 }

--- a/src/main/java/ceos/diggindie/domain/board/repository/BoardLikeRepository.java
+++ b/src/main/java/ceos/diggindie/domain/board/repository/BoardLikeRepository.java
@@ -1,7 +1,13 @@
 package ceos.diggindie.domain.board.repository;
 
+import ceos.diggindie.domain.board.entity.board.Board;
 import ceos.diggindie.domain.board.entity.board.BoardLike;
+import ceos.diggindie.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,4 +18,12 @@ public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
     boolean existsByMemberIdAndBoardId(Long memberId, Long boardId);
 
     long countByBoardId(Long boardId);
+
+    @Query("""
+    SELECT b FROM BoardLike bl
+    JOIN bl.board b
+    WHERE bl.member = :member
+""")
+    Page<Board> findBoardsByMember(@Param("member") Member member, Pageable pageable);
+
 }

--- a/src/main/java/ceos/diggindie/domain/board/repository/BoardRepository.java
+++ b/src/main/java/ceos/diggindie/domain/board/repository/BoardRepository.java
@@ -2,6 +2,7 @@ package ceos.diggindie.domain.board.repository;
 
 import ceos.diggindie.common.enums.BoardCategory;
 import ceos.diggindie.domain.board.entity.board.Board;
+import ceos.diggindie.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -35,4 +36,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Page<Board> findByCategoryAndQueryWithImages(@Param("category") BoardCategory category,
                                                  @Param("query") String query,
                                                  Pageable pageable);
+
+    Page<Board> findByMemberOrderByCreatedAtDesc(Member member, Pageable pageable);
+
 }

--- a/src/main/java/ceos/diggindie/domain/board/repository/MarketRepository.java
+++ b/src/main/java/ceos/diggindie/domain/board/repository/MarketRepository.java
@@ -2,6 +2,7 @@ package ceos.diggindie.domain.board.repository;
 
 import ceos.diggindie.common.enums.MarketType;
 import ceos.diggindie.domain.board.entity.market.Market;
+import ceos.diggindie.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -43,4 +44,7 @@ public interface MarketRepository extends JpaRepository<Market, Long> {
             "ORDER BY m.createdAt DESC",
             countQuery = "SELECT COUNT(m) FROM Market m WHERE m.type = :type AND (m.title ILIKE %:query% OR m.content ILIKE %:query%)")
     Page<Market> findByTypeAndQueryWithImages(@Param("type") MarketType type, @Param("query") String query, Pageable pageable);
+
+    Page<Market> findByMemberOrderByCreatedAtDesc(Member member, Pageable pageable);
+
 }

--- a/src/main/java/ceos/diggindie/domain/board/repository/MarketScrapRepository.java
+++ b/src/main/java/ceos/diggindie/domain/board/repository/MarketScrapRepository.java
@@ -1,7 +1,13 @@
 package ceos.diggindie.domain.board.repository;
 
+import ceos.diggindie.domain.board.entity.market.Market;
 import ceos.diggindie.domain.board.entity.market.MarketScrap;
 import org.springframework.data.jpa.repository.JpaRepository;
+import ceos.diggindie.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,4 +18,11 @@ public interface MarketScrapRepository extends JpaRepository<MarketScrap, Long> 
     boolean existsByMemberIdAndMarketId(Long memberId, Long marketId);
 
     long countByMarketId(Long marketId);
+
+    @Query("""
+    SELECT m FROM MarketScrap ms
+    JOIN ms.market m
+    WHERE ms.member = :member
+""")
+    Page<Market> findMarketsByMember(@Param("member") Member member, Pageable pageable);
 }

--- a/src/main/java/ceos/diggindie/domain/member/controller/AuthController.java
+++ b/src/main/java/ceos/diggindie/domain/member/controller/AuthController.java
@@ -8,6 +8,7 @@ import ceos.diggindie.domain.member.dto.*;
 import ceos.diggindie.domain.member.dto.auth.*;
 import ceos.diggindie.domain.member.dto.oauth.*;
 import ceos.diggindie.domain.member.service.AuthService;
+import ceos.diggindie.domain.member.service.EmailService;
 import ceos.diggindie.domain.member.service.MemberService;
 import ceos.diggindie.domain.member.service.OAuth2Service;
 import io.swagger.v3.oas.annotations.Operation;
@@ -32,6 +33,7 @@ public class AuthController {
     private final AuthService authService;
     private final OAuth2Service oAuth2Service;
     private final MemberService memberService;
+    private final EmailService emailService;
 
     @Operation(summary = "회원가입", description = "새로운 회원을 등록합니다.")
     @ApiResponses({
@@ -256,4 +258,22 @@ public class AuthController {
         return ResponseEntity.ok().body(response);
     }
 
+    @Operation(
+            summary = "비밀번호 재설정",
+            description = "이메일 인증 후 발급받은 resetToken으로 비밀번호를 변경합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 토큰 또는 비밀번호 형식 오류"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 이메일")
+    })
+    @PostMapping("/auth/password/reset")
+    public ResponseEntity<Response<String>> resetPassword(
+            @Valid @RequestBody PasswordResetRequest request
+    ) {
+        emailService.resetPassword(request);
+        return ResponseEntity.ok(
+                Response.success(SuccessCode.UPDATE_SUCCESS, "비밀번호가 변경되었습니다.")
+        );
+    }
 }

--- a/src/main/java/ceos/diggindie/domain/member/controller/EmailController.java
+++ b/src/main/java/ceos/diggindie/domain/member/controller/EmailController.java
@@ -44,7 +44,7 @@ public class EmailController {
 
     @Operation(
             summary = "인증 코드 확인",
-            description = "인증 코드를 확인합니다. PASSWORD_RESET은 newPassword 필수, FIND_USER_ID는 마스킹된 아이디 반환"
+            description = "인증 코드를 확인합니다. PASSWORD_RESET은 resetToken 반환, FIND_USER_ID는 마스킹된 아이디 반환"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "인증 성공"),

--- a/src/main/java/ceos/diggindie/domain/member/controller/MyPageController.java
+++ b/src/main/java/ceos/diggindie/domain/member/controller/MyPageController.java
@@ -1,0 +1,117 @@
+package ceos.diggindie.domain.member.controller;
+
+import ceos.diggindie.common.code.SuccessCode;
+import ceos.diggindie.common.config.security.CustomUserDetails;
+import ceos.diggindie.common.response.Response;
+import ceos.diggindie.domain.member.dto.mypage.*;
+import ceos.diggindie.domain.member.service.MyPageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "MyPage", description = "마이페이지 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/my")
+@PreAuthorize("isAuthenticated()")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    private static final String SORT_PROPERTY = "createdAt";
+
+    @Operation(summary = "내가 쓴 자유게시판 글 조회")
+    @GetMapping("/posts/board")
+    public ResponseEntity<Response<List<MyBoardPostResponse>>> getMyBoardPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(SORT_PROPERTY).descending());
+
+        Response<List<MyBoardPostResponse>> response = Response.success(
+                SuccessCode.GET_SUCCESS,
+                myPageService.getMyBoardPosts(userDetails.getExternalId(), pageable),
+                "마이페이지 내가 쓴 자유게시판 글 API"
+        );
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "내가 쓴 마켓 글 조회")
+    @GetMapping("/posts/market")
+    public ResponseEntity<Response<List<MyMarketPostResponse>>> getMyMarketPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(SORT_PROPERTY).descending());
+
+        Response<List<MyMarketPostResponse>> response = Response.success(
+                SuccessCode.GET_SUCCESS,
+                myPageService.getMyMarketPosts(userDetails.getExternalId(), pageable),
+                "마이페이지 내가 쓴 마켓 글 API"
+        );
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "내가 댓글 단 게시물 조회 (자유게시판)")
+    @GetMapping("/comments")
+    public ResponseEntity<Response<List<MyCommentedPostResponse>>> getMyCommentedPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        Response<List<MyCommentedPostResponse>> response = Response.success(
+                SuccessCode.GET_SUCCESS,
+                myPageService.getMyCommentedPosts(userDetails.getExternalId(), pageable),
+                "마이페이지 내가 댓글 단 게시물 API"
+        );
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "좋아요한 게시물 조회 (자유게시판)")
+    @GetMapping("/likes")
+    public ResponseEntity<Response<List<MyLikedPostResponse>>> getMyLikedPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(SORT_PROPERTY).descending());
+
+        Response<List<MyLikedPostResponse>> response = Response.success(
+                SuccessCode.GET_SUCCESS,
+                myPageService.getMyLikedPosts(userDetails.getExternalId(), pageable),
+                "마이페이지 좋아요한 게시물 API"
+        );
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "스크랩한 게시물 조회 (거래게시판)")
+    @GetMapping("/scraps")
+    public ResponseEntity<Response<List<MyScrappedPostResponse>>> getMyScrappedPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(SORT_PROPERTY).descending());
+
+        Response<List<MyScrappedPostResponse>> response = Response.success(
+                SuccessCode.GET_SUCCESS,
+                myPageService.getMyScrappedPosts(userDetails.getExternalId(), pageable),
+                "마이페이지 스크랩한 게시물 API"
+        );
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/dto/PasswordResetRequest.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/PasswordResetRequest.java
@@ -1,0 +1,10 @@
+package ceos.diggindie.domain.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordResetRequest(
+        @NotBlank @Email String email,
+        @NotBlank String resetToken,
+        @NotBlank String newPassword
+) {}

--- a/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerificationResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerificationResponse.java
@@ -1,18 +1,36 @@
 package ceos.diggindie.domain.member.dto.email;
 
+import ceos.diggindie.common.enums.EmailType;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalDateTime;
 
+import static ceos.diggindie.common.enums.EmailType.*;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record EmailVerificationResponse(
-        String message,
-        boolean success,
-        String userId,  // FIND_USER_ID일 때만 반환
-        LocalDateTime createdAt
+        EmailType message,
+        String resetToken,      // PASSWORD_RESET용
+        String maskedUserId,    // FIND_USER_ID용
+        LocalDateTime createdAt // FIND_USER_ID용
 ) {
-    public EmailVerificationResponse(String message, boolean success) {
-        this(message, success, null, null);
+
+
+    public static EmailVerificationResponse codeSent() {
+        return new EmailVerificationResponse(MSG_CODE_SENT, null, null, null);
     }
 
-    public EmailVerificationResponse(String message, boolean success, String userId) {
-        this(message, success, userId, null);
+    // 회원가입 등 기본 인증 성공 (SIGNUP)
+    public static EmailVerificationResponse successSignup() {
+        return new EmailVerificationResponse(MSG_SIGNUP_SUCCESS, null, null, null);
+    }
+
+    // 비밀번호 재설정용 (PASSWORD_RESET)
+    public static EmailVerificationResponse successPasswordReset(String resetToken) {
+        return new EmailVerificationResponse(MSG_PASSWORD_RESET_SUCCESS, resetToken, null, null);
+    }
+
+    // 아이디 찾기용 (FIND_USER_ID)
+    public static EmailVerificationResponse successFindUserId(String maskedUserId, LocalDateTime createdAt) {
+        return new EmailVerificationResponse(MSG_FIND_ID_SUCCESS, null, maskedUserId, createdAt);
     }
 }

--- a/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerifyRequest.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/email/EmailVerifyRequest.java
@@ -15,8 +15,5 @@ public record EmailVerifyRequest(
         String code,
 
         @NotNull(message = "인증 타입은 필수입니다.")
-        EmailVerificationType type,
-
-        @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
-        String newPassword  // PASSWORD_RESET일 때만 필수
+        EmailVerificationType type
 ) {}

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyBoardPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyBoardPostResponse.java
@@ -1,0 +1,31 @@
+package ceos.diggindie.domain.member.dto.mypage;
+
+import ceos.diggindie.common.utils.TimeUtils;
+import ceos.diggindie.domain.board.entity.board.Board;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@Builder
+public record MyBoardPostResponse(
+        Long boardId,
+        String category,
+        String title,
+        String content,
+        int views,
+        int likeCount,
+        int imageCount,
+        String createdAt
+) {
+    public static MyBoardPostResponse from(Board board) {
+        return MyBoardPostResponse.builder()
+                .boardId(board.getId())
+                .category(board.getCategory() != null ? board.getCategory().getDescription() : null)
+                .title(board.getTitle())
+                .content(board.getContent())
+                .views(board.getViews())
+                .likeCount(board.getBoardLikes().size())
+                .imageCount(board.getBoardImages() != null ? board.getBoardImages().size() : 0)
+                .createdAt(TimeUtils.toRelativeTime(board.getCreatedAt()))
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyCommentedPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyCommentedPostResponse.java
@@ -1,0 +1,34 @@
+package ceos.diggindie.domain.member.dto.mypage;
+
+import ceos.diggindie.common.utils.TimeUtils;
+import ceos.diggindie.domain.board.entity.board.Board;
+import lombok.Builder;
+
+@Builder
+public record MyCommentedPostResponse(
+        Long boardId,
+        String category,
+        String title,
+        String content,
+        String thumbnailUrl,
+        int views,
+        int likeCount,
+        int imageCount,
+        String createdAt
+) {
+    public static MyCommentedPostResponse from(Board board) {
+        return MyCommentedPostResponse.builder()
+                .boardId(board.getId())
+                .category(board.getCategory() != null ? board.getCategory().getDescription() : null)
+                .title(board.getTitle())
+                .content(board.getContent())
+                .thumbnailUrl(board.getBoardImages() != null && !board.getBoardImages().isEmpty()
+                        ? board.getBoardImages().get(0).getImageUrl()
+                        : null)
+                .views(board.getViews())
+                .likeCount(board.getBoardLikes().size())
+                .imageCount(board.getBoardImages() != null ? board.getBoardImages().size() : 0)
+                .createdAt(TimeUtils.toRelativeTime(board.getCreatedAt()))
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyLikedPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyLikedPostResponse.java
@@ -1,0 +1,34 @@
+package ceos.diggindie.domain.member.dto.mypage;
+
+import ceos.diggindie.common.utils.TimeUtils;
+import ceos.diggindie.domain.board.entity.board.Board;
+import lombok.Builder;
+
+@Builder
+public record MyLikedPostResponse(
+        Long boardId,
+        String category,
+        String title,
+        String content,
+        String thumbnailUrl,
+        int views,
+        int likeCount,
+        int imageCount,
+        String createdAt
+) {
+    public static MyLikedPostResponse from(Board board) {
+        return MyLikedPostResponse.builder()
+                .boardId(board.getId())
+                .category(board.getCategory() != null ? board.getCategory().getDescription() : null)
+                .title(board.getTitle())
+                .content(board.getContent())
+                .thumbnailUrl(board.getBoardImages() != null && !board.getBoardImages().isEmpty()
+                        ? board.getBoardImages().get(0).getImageUrl()
+                        : null)
+                .views(board.getViews())
+                .likeCount(board.getBoardLikes().size())
+                .imageCount(board.getBoardImages() != null ? board.getBoardImages().size() : 0)
+                .createdAt(TimeUtils.toRelativeTime(board.getCreatedAt()))
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyMarketPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyMarketPostResponse.java
@@ -1,0 +1,30 @@
+package ceos.diggindie.domain.member.dto.mypage;
+
+import ceos.diggindie.common.utils.TimeUtils;
+import ceos.diggindie.domain.board.entity.market.Market;
+import lombok.Builder;
+
+@Builder
+public record MyMarketPostResponse(
+        Long marketId,
+        String category,
+        String title,
+        Integer price,
+        String thumbnailUrl,
+        int scrapCount,
+        String createdAt
+) {
+    public static MyMarketPostResponse from(Market market) {
+        return MyMarketPostResponse.builder()
+                .marketId(market.getId())
+                .category(market.getType() != null ? market.getType().getDisplayName() : null)
+                .title(market.getTitle())
+                .price(market.getPrice())
+                .thumbnailUrl(market.getMarketImages() != null && !market.getMarketImages().isEmpty()
+                        ? market.getMarketImages().get(0).getImageUrl()
+                        : null)
+                .scrapCount(market.getMarketScraps().size())
+                .createdAt(TimeUtils.toRelativeTime(market.getCreatedAt()))
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyScrappedPostResponse.java
+++ b/src/main/java/ceos/diggindie/domain/member/dto/mypage/MyScrappedPostResponse.java
@@ -1,0 +1,31 @@
+package ceos.diggindie.domain.member.dto.mypage;
+
+import ceos.diggindie.common.utils.TimeUtils;
+import ceos.diggindie.domain.board.entity.market.Market;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@Builder
+public record MyScrappedPostResponse(
+        Long marketId,
+        String category,
+        String title,
+        Integer price,
+        String thumbnailUrl,
+        int scrapCount,
+        String createdAt
+) {
+    public static MyScrappedPostResponse from(Market market) {
+        return MyScrappedPostResponse.builder()
+                .marketId(market.getId())
+                .category(market.getType() != null ? market.getType().getDisplayName() : null)
+                .title(market.getTitle())
+                .price(market.getPrice())
+                .thumbnailUrl(market.getMarketImages() != null && !market.getMarketImages().isEmpty()
+                        ? market.getMarketImages().get(0).getImageUrl()
+                        : null)
+                .scrapCount(market.getMarketScraps().size())
+                .createdAt(TimeUtils.toRelativeTime(market.getCreatedAt()))
+                .build();
+    }
+}

--- a/src/main/java/ceos/diggindie/domain/member/service/MemberService.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/MemberService.java
@@ -23,19 +23,6 @@ public class MemberService {
                         "회원을 찾을 수 없습니다."));
     }
 
-    public Member findByEmail(String email) {
-        return memberRepository.findByEmail(email)
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.MEMBER_NOT_FOUND,
-                        "회원을 찾을 수 없습니다."));
-    }
-
-    public Member findByUserId(String userId) {
-        return memberRepository.findByUserId(userId)
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.MEMBER_NOT_FOUND,
-                        "회원을 찾을 수 없습니다."));
-    }
-
-
     @Transactional
     public MarketingConsentResponse updateMarketingConsent(String externalId, MarketingConsentRequest request) {
         Member member = memberRepository.findByExternalId(externalId)

--- a/src/main/java/ceos/diggindie/domain/member/service/MyPageService.java
+++ b/src/main/java/ceos/diggindie/domain/member/service/MyPageService.java
@@ -1,0 +1,69 @@
+package ceos.diggindie.domain.member.service;
+
+import ceos.diggindie.common.code.BusinessErrorCode;
+import ceos.diggindie.common.enums.PostType;
+import ceos.diggindie.common.exception.BusinessException;
+import ceos.diggindie.domain.board.repository.*;
+import ceos.diggindie.domain.member.dto.mypage.*;
+import ceos.diggindie.domain.member.entity.Member;
+import ceos.diggindie.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageService {
+
+    private final MemberRepository memberRepository;
+    private final BoardRepository boardRepository;
+    private final MarketRepository marketRepository;
+    private final BoardCommentRepository boardCommentRepository;
+    private final BoardLikeRepository boardLikeRepository;
+    private final MarketScrapRepository marketScrapRepository;
+
+    // 내가 쓴 자유게시판 글 조회
+    public Page<MyBoardPostResponse> getMyBoardPosts(String externalId, Pageable pageable) {
+        Member member = findMember(externalId);
+        return boardRepository.findByMemberOrderByCreatedAtDesc(member, pageable)
+                .map(MyBoardPostResponse::from);
+    }
+
+    // 내가 쓴 마켓 글 조회
+    public Page<MyMarketPostResponse> getMyMarketPosts(String externalId, Pageable pageable) {
+        Member member = findMember(externalId);
+        return marketRepository.findByMemberOrderByCreatedAtDesc(member, pageable)
+                .map(MyMarketPostResponse::from);
+    }
+
+    // 내가 댓글 단 게시물 조회 (자유게시판)
+    public Page<MyCommentedPostResponse> getMyCommentedPosts(String externalId, Pageable pageable) {
+        Member member = findMember(externalId);
+        return boardCommentRepository.findDistinctBoardsByMember(member, pageable)
+                .map(MyCommentedPostResponse::from);
+    }
+
+    // 좋아요한 게시물 조회 (자유게시판)
+    public Page<MyLikedPostResponse> getMyLikedPosts(String externalId, Pageable pageable) {
+        Member member = findMember(externalId);
+        return boardLikeRepository.findBoardsByMember(member, pageable)
+                .map(MyLikedPostResponse::from);
+    }
+
+    // 스크랩한 양도글 조회 (거래게시판)
+    public Page<MyScrappedPostResponse> getMyScrappedPosts(String externalId, Pageable pageable) {
+        Member member = findMember(externalId);
+        return marketScrapRepository.findMarketsByMember(member, pageable)
+                .map(MyScrappedPostResponse::from);
+    }
+
+    private Member findMember(String externalId) {
+        return memberRepository.findByExternalId(externalId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.MEMBER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
* refactor: 비밀번호 재설정 api 분리

* feat: mypage 관련 기능 개발

* fix: 이중정렬 문제 해결

* chore: null인 항목 보이게 수정

* fix: 코드리뷰 반영

* chore: enum 분리

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->



## ⚠️ PR 특이 사항




## 📚 Reference




### ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 포스트맨에서 결과값을 제대로 확인했나요?
- [ ] 리뷰어 설정을 지정했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
