### PR TITLE
[REFACTOR] 이메일 사용중일 경우 자동으로 연동되도록 로직 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,9 +100,11 @@ jobs:
             
             cat > docker-compose.yml <<-'INNER_EOF'
             version: '3.8'
+            
             services:
               app:
                 image: ${AWS_ACCOUNT_ID}.dkr.ecr.ap-northeast-2.amazonaws.com/diggindie-dev:latest
+                container_name: diggindie-be
                 ports:
                   - "8080:8080"
                 environment:
@@ -127,7 +129,7 @@ jobs:
                   - NAVER_CLIENT_ID=${NAVER_CLIENT_ID}
                   - NAVER_CLIENT_SECRET=${NAVER_CLIENT_SECRET}
                   - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
-                  - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET} 
+                  - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
                   - MAIL_USERNAME=${MAIL_USERNAME}
                   - MAIL_PASSWORD=${MAIL_PASSWORD}
                   - AWS_S3_BUCKET=${AWS_S3_BUCKET}
@@ -135,19 +137,40 @@ jobs:
                   - AWS_SECRET_KEY=${AWS_SECRET_KEY}
                   - AWS_REGION=${AWS_REGION}
                 depends_on:
-                  - redis
+                  redis:
+                    condition: service_healthy
                 restart: unless-stopped
+                networks:
+                  - app-network
             
               redis:
-                image: redis:alpine
+                image: redis:7
+                container_name: redis
                 ports:
                   - "6379:6379"
+                volumes:
+                  - redis-data:/data
+                command: ["redis-server", "--appendonly", "yes"]
                 environment:
                   - TZ=Asia/Seoul
+                healthcheck:
+                  test: ["CMD", "redis-cli", "ping"]
+                  interval: 5s
+                  timeout: 3s
+                  retries: 5
                 restart: unless-stopped
+                networks:
+                  - app-network
+            
+            networks:
+              app-network:
+                driver: bridge
+            
+            volumes:
+              redis-data:
             INNER_EOF
 
             aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.ap-northeast-2.amazonaws.com
             
             docker-compose pull
-            docker-compose up -d --force-recreate app
+            docker-compose up -d --force-recreate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
     restart: unless-stopped
+    networks:
+      - app-network
 
   redis:
     image: redis:7
@@ -32,6 +34,12 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge
 
 volumes:
   redis-data:


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #118


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->

- OAuth2 로그인 시 이메일 중복인 경우 추가
  - 네이버로 가입 후 같은 이메일의 카카오 계정으로 로그인 시 자동 계정 연동 처리
  - `processLogin` 메서드에 이메일 기반 회원 조회 로직 추가
  - 기존 회원이 있으면 새 소셜 계정만 연동하고 로그인 처리
- 사용하지 않는 메서드 제거
  - `validateStateForLogin`, `validateStateForLink` 메서드 삭제 (중복 검증 로직)


## 📚 Reference




### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
