### PR TITLE
[FEAT] 밴드 관련 로직 수정

### DIFF
--- a/src/main/java/ceos/diggindie/domain/band/entity/Band.java
+++ b/src/main/java/ceos/diggindie/domain/band/entity/Band.java
@@ -41,7 +41,7 @@ public class Band extends BaseEntity {
     private String spotifyId;
 
     @Column(name = "is_band", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
-    private Boolean isBand;
+    private Boolean isBand = false;
 
     @OneToMany(mappedBy = "band", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Artist> artists = new ArrayList<>();

--- a/src/main/java/ceos/diggindie/domain/band/entity/Band.java
+++ b/src/main/java/ceos/diggindie/domain/band/entity/Band.java
@@ -37,11 +37,11 @@ public class Band extends BaseEntity {
     @Column(name = "main_music", length = 200)
     private String mainMusic;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String description;
-
     @Column(name = "spotify_id", length = 100)
     private String spotifyId;
+
+    @Column(name = "is_band", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean isBand;
 
     @OneToMany(mappedBy = "band", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Artist> artists = new ArrayList<>();
@@ -68,20 +68,21 @@ public class Band extends BaseEntity {
     @OneToOne(mappedBy = "band", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
     private TopTrack topTrack;
 
+    @OneToOne(mappedBy = "band", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private BandDescription bandDescription;
+
     @Builder
     public Band(
             String bandName,
             String mainImage,
             String mainUrl,
             String mainMusic,
-            String description,
             String spotifyId
     ) {
         this.bandName = bandName;
         this.mainImage = mainImage;
         this.mainUrl = mainUrl;
         this.mainMusic = mainMusic;
-        this.description = description;
         this.spotifyId = spotifyId;
     }
 

--- a/src/main/java/ceos/diggindie/domain/band/entity/BandDescription.java
+++ b/src/main/java/ceos/diggindie/domain/band/entity/BandDescription.java
@@ -3,6 +3,7 @@ package ceos.diggindie.domain.band.entity;
 import ceos.diggindie.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,4 +28,10 @@ public class BandDescription extends BaseEntity {
     // TODO: 나중에 converter로 구현 시 변경할 컬럼
     @Transient
     private float[] embedding;
+
+    @Builder
+    public BandDescription(Band band, String description) {
+        this.band = band;
+        this.description = description;
+    }
 }

--- a/src/main/java/ceos/diggindie/domain/band/repository/BandDescriptionRepository.java
+++ b/src/main/java/ceos/diggindie/domain/band/repository/BandDescriptionRepository.java
@@ -1,0 +1,13 @@
+package ceos.diggindie.domain.band.repository;
+
+import ceos.diggindie.domain.band.entity.BandDescription;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BandDescriptionRepository extends JpaRepository<BandDescription, Long> {
+    
+    Optional<BandDescription> findByBandId(Long bandId);
+}

--- a/src/main/java/ceos/diggindie/domain/concert/service/ConcertAppender.java
+++ b/src/main/java/ceos/diggindie/domain/concert/service/ConcertAppender.java
@@ -98,7 +98,6 @@ public class ConcertAppender {
                     .orElseGet(() -> bandRepository.save(
                             Band.builder()
                                     .bandName(name)
-                                    .description(name)
                                     .build()
                     ));
 

--- a/src/main/java/ceos/diggindie/domain/keyword/service/KeywordService.java
+++ b/src/main/java/ceos/diggindie/domain/keyword/service/KeywordService.java
@@ -153,7 +153,6 @@ public class KeywordService {
             
             [아티스트 정보]
             - 이름: %s
-            - 설명: %s
             - 대표곡: %s
             
             [키워드 목록]
@@ -163,7 +162,6 @@ public class KeywordService {
             예시: ["서정적", "잔잔한"]
             """.formatted(
                 band.getBandName(),
-                band.getDescription() != null ? band.getDescription() : "정보 없음",
                 band.getMainMusic() != null ? band.getMainMusic() : "정보 없음",
                 keywordList
         );

--- a/src/main/java/ceos/diggindie/domain/openai/controller/OpenAIController.java
+++ b/src/main/java/ceos/diggindie/domain/openai/controller/OpenAIController.java
@@ -3,6 +3,7 @@ package ceos.diggindie.domain.openai.controller;
 import ceos.diggindie.domain.openai.dto.BandDescriptionRequest;
 import ceos.diggindie.domain.openai.dto.PromptRequest;
 import ceos.diggindie.domain.openai.service.OpenAIService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+@Hidden
 @Tag(name = "OpenAI", description = "OpenAI 관련 API (백엔드 내부용)")
 @RestController
 @RequiredArgsConstructor
@@ -38,7 +40,7 @@ public class OpenAIController {
             @ApiResponse(responseCode = "200", description = "생성 완료"),
             @ApiResponse(responseCode = "403", description = "권한 없음 (ADMIN만 접근 가능)")
     })
-    @PostMapping("/admin/openai/band-descriptions")
+    @PostMapping("/api/admin/openai/band-descriptions")
     public String generateBandDescriptions(@RequestBody BandDescriptionRequest request) {
         return openAIService.generateBandDescriptions(request.startBandId());
     }

--- a/src/main/java/ceos/diggindie/domain/openai/controller/OpenAIController.java
+++ b/src/main/java/ceos/diggindie/domain/openai/controller/OpenAIController.java
@@ -1,11 +1,9 @@
 package ceos.diggindie.domain.openai.controller;
 
+import ceos.diggindie.domain.openai.dto.BandDescriptionRequest;
 import ceos.diggindie.domain.openai.dto.PromptRequest;
 import ceos.diggindie.domain.openai.service.OpenAIService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,10 +25,22 @@ public class OpenAIController {
             @ApiResponse(responseCode = "403", description = "권한 없음 (ADMIN만 접근 가능)")
     })
     @PostMapping("/api/admin/openai")
-    public String chat(
-            @RequestBody(description = "프롬프트 요청") @org.springframework.web.bind.annotation.RequestBody PromptRequest prompt
-    ) {
+    public String chat(@RequestBody PromptRequest prompt) {
         return openAIService.callOpenAI(prompt);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(
+            summary = "밴드 설명 자동 생성 [내부용]",
+            description = "특정 band_id 이후의 모든 밴드에 대해 GPT로 음악적 설명을 생성하고 band_description 테이블에 저장합니다. ADMIN 권한 필요."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "생성 완료"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (ADMIN만 접근 가능)")
+    })
+    @PostMapping("/admin/openai/band-descriptions")
+    public String generateBandDescriptions(@RequestBody BandDescriptionRequest request) {
+        return openAIService.generateBandDescriptions(request.startBandId());
     }
 
 }

--- a/src/main/java/ceos/diggindie/domain/openai/dto/BandDescriptionRequest.java
+++ b/src/main/java/ceos/diggindie/domain/openai/dto/BandDescriptionRequest.java
@@ -1,0 +1,10 @@
+package ceos.diggindie.domain.openai.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "밴드 설명 생성 요청")
+public record BandDescriptionRequest(
+        @Schema(description = "시작 band_id (해당 ID 이후의 모든 밴드 처리)", example = "1")
+        Long startBandId
+) {
+}

--- a/src/main/java/ceos/diggindie/domain/openai/service/OpenAIService.java
+++ b/src/main/java/ceos/diggindie/domain/openai/service/OpenAIService.java
@@ -1,15 +1,20 @@
 package ceos.diggindie.domain.openai.service;
 
+import ceos.diggindie.domain.band.entity.Band;
+import ceos.diggindie.domain.band.entity.BandDescription;
+import ceos.diggindie.domain.band.repository.BandDescriptionRepository;
+import ceos.diggindie.domain.band.repository.BandRepository;
 import ceos.diggindie.domain.openai.dto.OpenAIRequest;
 import ceos.diggindie.domain.openai.dto.OpenAIResponse;
 import ceos.diggindie.domain.openai.dto.PromptRequest;
-import ceos.diggindie.domain.spotify.dto.SpotifySearchResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClient;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -24,6 +29,8 @@ public class OpenAIService {
     private String MODEL;
 
     private final RestClient restClient;
+    private final BandRepository bandRepository;
+    private final BandDescriptionRepository bandDescriptionRepository;
 
     public String callOpenAI(PromptRequest request) {
 
@@ -50,6 +57,84 @@ public class OpenAIService {
                 .filter(c -> c.text() != null)
                 .map(OpenAIResponse.ContentItem::text)
                 .collect(Collectors.joining("\n"));
+
+        return result;
+    }
+
+    @Transactional
+    public String generateBandDescriptions(Long startBandId) {
+        // 1. 특정 band_id 이후의 모든 밴드 조회
+        List<Band> bands = bandRepository.findAll().stream()
+                .filter(band -> band.getId() >= startBandId)
+                .toList();
+
+        int total = bands.size();
+        int completed = 0;
+        int skipped = 0;
+        int failed = 0;
+
+        log.info("========== 밴드 설명 생성 시작 (총 {}개, ID >= {}) ==========", total, startBandId);
+
+        for (Band band : bands) {
+            try {
+                // 2. 이미 설명이 있는 경우 스킵
+                if (bandDescriptionRepository.findByBandId(band.getId()).isPresent()) {
+                    skipped++;
+                    log.info("[{}/{}] {} - 스킵 (이미 존재)", completed + skipped + failed, total, band.getBandName());
+                    continue;
+                }
+
+                // 3. GPT 프롬프트 생성
+                String prompt = String.format("""
+                        다음 가수에 대한 음악적 특색을 드러내는 간결한 설명을 작성해줘.
+                        
+                        가수/밴드명: %s
+                        
+                        작성 규칙:
+                        - 최대 6문장으로 작성
+                        - 음악 장르, 멜로디 특징, 가사 주제, 공연 특징 등을 포함
+                        - "-이다" 형태의 정중한 문체 사용
+                        - 설명만 작성하고 다른 멘트는 절대 포함하지 말 것
+                        
+                        예시:
+                        극동아시아타이거즈는 펑키하면서도 신나는 멜로디와 공감 가는 가사를 특징으로 하는 펑크 록 밴드이다. 우당탕탕 음악으로 추억을 노래하는 밴드라는 슬로건처럼 정제되지 않은 날 것의 느낌과 익살스러움 속에 향수를 담아내며, 라이브 공연에서 특히 빛을 발한다.
+                        
+                        정고래는 감성적인 발라드와 인디팝을 중심으로 따뜻하고 담백한 멜로디와 편곡이 특징인 솔로 아티스트이다. 주로 잊혀지지 않는 기억과 이별, 위로를 주제로 한 곡들을 선보인다
+                        """, band.getBandName());
+
+                // 4. GPT 호출
+                String description = callOpenAI(new PromptRequest(prompt));
+
+                if (description == null || description.isBlank()) {
+                    failed++;
+                    log.warn("[{}/{}] {} - 실패 (GPT 응답 없음)", completed + skipped + failed, total, band.getBandName());
+                    continue;
+                }
+
+                // 5. BandDescription 저장
+                BandDescription bandDescription = BandDescription.builder()
+                        .band(band)
+                        .description(description.trim())
+                        .build();
+
+                bandDescriptionRepository.save(bandDescription);
+                completed++;
+
+                log.info("[{}/{}] {} - 완료", completed + skipped + failed, total, band.getBandName());
+
+            } catch (Exception e) {
+                failed++;
+                log.error("[{}/{}] {} - 오류: {}", completed + skipped + failed, total, band.getBandName(), e.getMessage());
+            }
+        }
+
+        String result = String.format(
+                "밴드 설명 생성 완료\n총 %d개 중 성공: %d개, 스킵: %d개, 실패: %d개",
+                total, completed, skipped, failed
+        );
+
+        log.info("========== 완료 ==========");
+        log.info(result);
 
         return result;
     }


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #120 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- 밴드 엔티티 수정(description 삭제) 및 이와 관련한 로직의 에러 핸들링을 수행하였습니다.
- 밴드 테이블에 is_band 칼럼을 추가하고 이를 기반으로 밴드 이외의 가수를 DB에 추가하였습니다.
- 새로운 가수들의 설명을 추가하는 openAI 연동 API를 개발하였습니다.
- `GET /artists`
  - 온보딩시 밴드 목록 반환에서 is_band=false 인 밴드들이 상단에 많이 위치하도록 개선하였습니다.
- `GET /artists/search?order={ }`
  - 온보딩 이외에 밴드 목록 반환에서는 is_band = true인 밴드들만 활용하도록 수정하였습니다.


## ⚠️ PR 특이 사항
- 테이블 구조 변경으로 인한 에러로 서버 동작이 마비되어 빠른 개선이 필요합니다!



## 📚 Reference




### ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 포스트맨에서 결과값을 제대로 확인했나요?
- [ ] 리뷰어 설정을 지정했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
